### PR TITLE
Replace hashtag with uswds link icon. Style.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -93,8 +93,8 @@ module.exports = function (config) {
   }).use(markdownItAnchor, {
     permalink: markdownItAnchor.permalink.ariaHidden({
       placement: 'after',
-      class: 'direct-link',
-      symbol: '#',
+      class: 'font-heading-lg text-primary-light hover:text-primary',
+      symbol: `<svg class="usa-icon" aria-hidden="true" role="img"><use xlink:href="#svg-link"></use></svg>`,
       level: [1, 2, 3, 4],
     }),
     slugify: config.getFilter('slug'),


### PR DESCRIPTION
## Context
Replace `#` icon in heading anchor links. Use 18F Guides style for anchor headers. Example: https://guides.18f.gov/engineering/our-approach/#all-projects-standard

## Description
Update the eleventy.js `MarkdownItAnchor` style and symbol attributes. Use the SVG from [USWDS Link icon](https://designsystem.digital.gov/components/icon/).

## How to verify this change

1. Navigate to a standards page. Next to each heading should be a light blue link icon. 
2. Hover over the icon. It should turn dark blue.
3. Click on the icon. The heading should jump to top focus and appended to the url.

## Additional information
<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. Include the Pages preview URL. It will be available once all the checks have passed. -->
🔗 [Preview URL](https://federalist-ce0b03c9-1a0d-440d-8d5d-6278c649a788.sites.pages.cloud.gov/preview/gsa-tts/federal-web-standards/cannandev/change-header-anchors/standards/banner/#why)
