### PR TITLE
Add status step indicator to each standard page

### DIFF
--- a/_includes/status/draft.html
+++ b/_includes/status/draft.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters outline-1px padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>

--- a/_includes/status/draft.html
+++ b/_includes/status/draft.html
@@ -1,0 +1,18 @@
+<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current" aria-current="true">
+      <span class="usa-step-indicator__segment-label">Draft</span>
+    </li>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">Pending<span class="usa-sr-only">not completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">Standard <span class="usa-sr-only">not completed</span></span>
+    </li>
+  </ol>
+
+  <p class="margin-top-4">The text of this potential standard has been drafted and is being shared with federal agencies and other stakeholders.</p>
+</div>

--- a/_includes/status/draft.html
+++ b/_includes/status/draft.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>

--- a/_includes/status/draft.html
+++ b/_includes/status/draft.html
@@ -14,5 +14,8 @@
     </li>
   </ol>
 
-  <p class="margin-top-4">The text of this potential standard has been drafted and is being shared with federal agencies and other stakeholders.</p>
+  <div class="margin-top-4">
+    <h3 class="desktop:display-none">Draft</h3>
+    <p class="margin-top-4">The text of this potential standard has been drafted and is being shared with federal agencies and other stakeholders.</p>
+  </div>
 </div>

--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>

--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>
@@ -15,7 +15,7 @@
   </ol>
 
   <div class="margin-top-4">
-    <h3 class="desktop:display-none">Pending</h3>
+    <p class="desktop:display-none text-bold">Pending</p>
     <p>This will become a standard after a period of time. Agencies should plan to implement this standard.</p>
   </div>
 </div>

--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -14,5 +14,8 @@
     </li>
   </ol>
 
-  <p class="margin-top-4">This will become a standard after a period of time. Agencies should plan to implement this standard.</p>
+  <div class="margin-top-4">
+    <h3 class="desktop:display-none">Pending</h3>
+    <p>This will become a standard after a period of time. Agencies should plan to implement this standard.</p>
+  </div>
 </div>

--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -1,0 +1,18 @@
+<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">Draft <span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current" aria-current="true">
+      <span class="usa-step-indicator__segment-label">Pending</span>
+    </li>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">Standard <span class="usa-sr-only">not completed</span></span>
+    </li>
+  </ol>
+
+  <p class="margin-top-4">This will become a standard after a period of time. Agencies should plan to implement this standard.</p>
+</div>

--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>

--- a/_includes/status/research.html
+++ b/_includes/status/research.html
@@ -1,0 +1,18 @@
+<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current" aria-current="true">
+      <span class="usa-step-indicator__segment-label">Research</span>
+    </li>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">Draft<span class="usa-sr-only">not completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">Pending<span class="usa-sr-only">not completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">Standard<span class="usa-sr-only">not completed</span></span>
+    </li>
+  </ol>
+
+  <p class="margin-top-4">This potential standard is being researched with the public and with federal agency staff.</p>
+</div>

--- a/_includes/status/research.html
+++ b/_includes/status/research.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--current" aria-current="true">
       <span class="usa-step-indicator__segment-label">Research</span>

--- a/_includes/status/research.html
+++ b/_includes/status/research.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--current" aria-current="true">
       <span class="usa-step-indicator__segment-label">Research</span>

--- a/_includes/status/research.html
+++ b/_includes/status/research.html
@@ -14,5 +14,8 @@
     </li>
   </ol>
 
-  <p class="margin-top-4">This potential standard is being researched with the public and with federal agency staff.</p>
+  <div class="margin-top-4">
+    <h3 class="desktop:display-none">Research</h3>
+    <p class="margin-top-4">This potential standard is being researched with the public and with federal agency staff.</p>
+  </div>
 </div>

--- a/_includes/status/standard.html
+++ b/_includes/status/standard.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>

--- a/_includes/status/standard.html
+++ b/_includes/status/standard.html
@@ -1,0 +1,18 @@
+<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">Draft<span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">Pending<span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current" aria-current="true">
+      <span class="usa-step-indicator__segment-label">Standard</span>
+    </li>
+  </ol>
+
+  <p class="margin-top-4">Federal agencies are required to comply with this standard.</p>
+</div>

--- a/_includes/status/standard.html
+++ b/_includes/status/standard.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest outline-1px padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>

--- a/_includes/status/standard.html
+++ b/_includes/status/standard.html
@@ -14,5 +14,8 @@
     </li>
   </ol>
 
-  <p class="margin-top-4">Federal agencies are required to comply with this standard.</p>
+  <div class="margin-top-4">
+    <h3 class="desktop:display-none">Standard</h3>
+    <p class="margin-top-4">Federal agencies are required to comply with this standard.</p>
+  </div>
 </div>

--- a/standards/banner.md
+++ b/standards/banner.md
@@ -11,14 +11,13 @@ eleventyExcludeFromCollections: false
 date: Last modified
 ---
 
+## Status
+
+{% include "_includes/status/pending.html" %}
+
 ## Standard
 
 Use the federal government banner at the top of every page to identify your site as an official federal government site.
-
-## Status
-
-Pending
-
 
 ## Why
 

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -11,13 +11,13 @@ surveyLink:
 date: Last modified
 ---
 
+## Status
+
+{% include "_includes/status/research.html" %}
+
 ## Potential standard
 
 Every website must include a contact page. Every web page or screen must link to your contact page. Your contact page must include all contact options for your agency, product, or service.
-
-## Status
-
-Research
 
 ## Why
 

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -11,13 +11,13 @@ surveyLink:
 date: Last modified
 ---
 
+## Status
+
+{% include "_includes/status/research.html" %}
+
 ## Potential standard
 
 Inform users about the timeliness of content.
-
-## Status
-
-Research
 
 ## Why
 

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -11,13 +11,13 @@ surveyLink:
 date: Last modified
 ---
 
+## Status
+
+{% include "_includes/status/pending.html" %}
+
 ## Standard
 
 Use a descriptive, unique, and concise HTML page title for every page of your website.
-
-## Status
-
-Pending
 
 ## Why
 

--- a/standards/meta-page-description.md
+++ b/standards/meta-page-description.md
@@ -11,13 +11,13 @@ surveyLink:
 date: Last modified
 ---
 
+## Status
+
+{% include "_includes/status/pending.html" %}
+
 ## Standard
 
 Summarize the content of the page in the meta description tag. The description should be unique and include key information about the page content.
-
-## Status
-
-Pending
 
 ## Why
 

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -12,13 +12,13 @@ pageFlowSection:
 date: Last modified
 ---
 
+## Status
+
+{% include "_includes/status/draft.html" %}
+
 ## Potential standard
 
 Public-facing websites must contain a search function that allows users to easily search content intended for public use. 
-
-## Status
-
-Draft
 
 ## Why
 


### PR DESCRIPTION
## Context
This adds the USWDS step indicator to each of the stand pages. Fixes #170 

## Description
On viewport sizes smaller than desktop (width < 1024px) we show the actual status label (Research, Draft, Pending, Standard) below the step indicator because the step indicator labels become hidden on those viewport sizes. The bolded label that I add for width < 1024px is not shown on Desktop or greater because the step indicator labels do that job.

## How this is implemented
Each status (Research, Draft, Pending, Standard) has its own partial within `_includes/status`, this should be included under the `## Status` heading on each standard. When the front matter status for a standard changes, the partial that is included should also be updated.

## How to verify this change
1. [Visit the standards page](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/status-step-indicator/standards/)
2. Click through the various standards to make sure the step indicator is showing the correct step and detail about what it means for a standard to be in the status that it's in
3. Emulate a mobile or tablet device (something with a width of less than 1024px) and verify that the status label (Research, Draft, Pending, Standard) shows below the step indicator. This is set to only render on viewports smaller than USWDS desktop because the step indicator component does not show its built-in labels on those smaller viewport sizes.

## Additional information
🔗 [Preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/status-step-indicator/standards/)
