### PR TITLE
Add external link icon class to all links with a TLD other than .gov

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,1 +1,21 @@
 require('@uswds/uswds');
+
+// Append the USWDS 'usa-link--external' class to any link whose TLD is not .gov
+document.addEventListener('DOMContentLoaded', () => {
+  Array.from(document.querySelectorAll('a[href]'))
+    // Filter out localhost and links to targets in the same page
+    .filter(({ href }) => !['localhost', ''].includes(new URL(href).hostname))
+    // Filter out .gov and .mil links
+    .filter(({ href }) => !/\.(gov|mil)$/i.test(new URL(href).hostname))
+    // Filter out social and logo links
+    .filter(
+      (anchor) =>
+        !['usa-social-link', 'usa-identifier__logo'].some((c) =>
+          anchor.className.includes(c)
+        )
+    )
+    // For all the remaining anchors, add the external link class
+    .forEach((anchor) => {
+      anchor.className = [anchor.className, 'usa-link--external'].join(' ')
+    })
+});


### PR DESCRIPTION
## Context
This adds the `usa-link--external` CSS class to any link on the current page whose top level domain ends in anything other than `.gov`. Fixes #174 

## Description
There is a JavaScript event listener which runs once all the DOM content has loaded that looks for links that should have the `usa-link--external` class added and adds it.

## How to verify this change
1. Visit the "Contact" [page](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/add-icon-to-external-links/contact/)
2. Observe that the two links inside of the heading "Follow our work on GitHub" have the external link icon applied
3. Observe that the email address link (a `mailto` link) does not have this external icon present
4. Look around at the links on other pages, they're primarily, if not exclusively, `.gov` links and should not have the external icon
