### PR TITLE
Remove automatic last modified dates for standards

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -50,6 +50,16 @@ module.exports = function (config) {
     return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat('yyyy-LL-dd');
   });
 
+  config.addFilter('toISOString', (dateObj, formatString) => {
+    let date;
+
+    console.log(formatString);
+    // https://moment.github.io/luxon/#/formatting?id=table-of-tokens
+    date = DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat(formatString);
+
+    return date;
+  });
+
   // Get the first `n` elements of a collection.
   config.addFilter('head', (array, n) => {
     if (!Array.isArray(array) || array.length === 0) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -51,10 +51,8 @@ module.exports = function (config) {
   });
 
   config.addFilter('toISOString', (dateObj, formatString) => {
-    let date;
-
     // https://moment.github.io/luxon/#/formatting?id=table-of-tokens
-    date = DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat(formatString);
+    const date = DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat(formatString);
 
     return date;
   });

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -52,9 +52,7 @@ module.exports = function (config) {
 
   config.addFilter('toISOString', (dateObj, formatString) => {
     // https://moment.github.io/luxon/#/formatting?id=table-of-tokens
-    const date = DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat(formatString);
-
-    return date;
+    return DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat(formatString);
   });
 
   // Get the first `n` elements of a collection.

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -53,7 +53,6 @@ module.exports = function (config) {
   config.addFilter('toISOString', (dateObj, formatString) => {
     let date;
 
-    console.log(formatString);
     // https://moment.github.io/luxon/#/formatting?id=table-of-tokens
     date = DateTime.fromJSDate(dateObj, { zone: 'utc' }).toFormat(formatString);
 

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -29,8 +29,8 @@ Federal website standards are evidence-based actions that will help agencies del
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
         <ul class="usa-collection__meta" aria-label="More information">
           <li class="usa-collection__meta-item">
-            Updated <time datetime="{{ standard.date | date: '%Y-%m-%dT12:00:00+01:00' }}">
-              {{ standard.date | date: '%B %d, %Y' }}
+            Updated <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+              {{ standard.date | toISOString: 'DDD' }}
             </time>
           </li>
         </ul>
@@ -59,8 +59,8 @@ Federal website standards are evidence-based actions that will help agencies del
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
         <ul class="usa-collection__meta" aria-label="More information">
           <li class="usa-collection__meta-item">
-            Updated <time datetime="{{ standard.date | date: '%Y-%m-%dT12:00:00+01:00' }}">
-              {{ standard.date | date: '%B %d, %Y' }}
+            Updated <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+              {{ standard.date | toISOString: 'DDD' }}
             </time>
           </li>
         </ul>

--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -28,8 +28,8 @@ This template is for a single page with meta data. It should feed the page-colum
     </div>
     <div class="grid-row text-italic margin-top-4" id="last-updated">
       <span>Last updated&nbsp;</span>
-      <time datetime="{{ page.date | date: '%Y-%m-%dT12:00:00+01:00' }}">
-       {{ page.date | date: '%B %d, %Y' }}
+      <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+       {{ page.date | toISOString: 'DDD' }}
       </time>
     </div>
     </div>

--- a/standards/banner.md
+++ b/standards/banner.md
@@ -8,7 +8,7 @@ status: Pending
 description: The federal government banner identifies official federal government sites. Learn how to implement the banner on your federal government site.
 surveyLink: 
 eleventyExcludeFromCollections: false
-date: Last modified
+date: "2024-09-12"
 ---
 
 ## Status

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -8,7 +8,7 @@ why: Contact information that is easily and consistently accessible builds trust
 status: Research
 description: A contact page is important for building trust and serving your users. Learn how to create a good contact page for your federal government site.
 surveyLink: 
-date: Last modified
+date: "2024-09-12"
 ---
 
 ## Status

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -8,7 +8,7 @@ why: Timeliness indicators can increase user trust in the currency and accuracy 
 status: Research
 description: Timeliness indicators can increase trust in the currency and accuracy of information. Learn how to add timeliness indicators on your federal government site.
 surveyLink: 
-date: Last modified
+date: "2024-09-12"
 ---
 
 ## Status

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -8,7 +8,7 @@ why: A descriptive page title is important for accessibility and discoverability
 status: Pending
 description: A descriptive and unique page title is important for accessibility and discoverability. Learn how to create quality HTML page titles for your federal government site.
 surveyLink: 
-date: Last modified
+date: "2024-09-12"
 ---
 
 ## Status

--- a/standards/meta-page-description.md
+++ b/standards/meta-page-description.md
@@ -8,7 +8,7 @@ why: The meta description supports accessibility and discoverability.
 status: Pending
 description: A descriptive and unique meta page description is important for accessibility and discoverability. Learn how to create quality meta page descriptions for your federal government site.
 surveyLink: 
-date: Last modified
+date: "2024-09-12"
 ---
 
 ## Status

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -9,7 +9,7 @@ status: Draft
 description: Search functionality is an expected feature for websites and digital services. Learn how to add a search capability to your federal government site.
 surveyLink: 
 pageFlowSection:
-date: Last modified
+date: "2024-09-12"
 ---
 
 ## Status


### PR DESCRIPTION
## Context
We're presenting information about standards; it's helpful to users if our content folks control the date displayed for "Last Modified". This allows the "last modified" date to change only if a change was made to a standard that is significant such as a status change or extra information. Previously the last modified date would update anytime a change was made to the file which is not helpful when something like a minor grammatical change is made.

Fixes #176 

## Description
This implements a new liquid filter called `toISOString` that accepts a parameter called `formatString`. We're currently showing our last modified dates in two different formats. One format is used to show the date as a human readable string like "September 12, 2024" and the other is used to populate the `datetime` attribute within `<time>` elements like `2024-09-12 00:00:00+00:00`.

`toISOString` is being used because the `date` filter included with Liquid renders the datetimes in a local zone which causes an off by one error. An example is if we use "date: 2024-09-12" in one of our markdown files and just pass that straight to the Liquid `date` filter using the "human readable" format we will get an output of "September 11, 2024" because the `date` filter uses "2024-09-12 00:00:00 UTC" and then localizes that during the build. You can read about this behavior on the [11ty content dates](https://www.11ty.dev/docs/dates/#dates-off-by-one-day) page. This could be avoided if we could guarantee that the `date` key in the front matter contained a valid time component with zone offset like `2024-09-12t21:59:43.10-05:00` but that seems like a tall ask.

## How to verify this change
1. Visit the [standards page](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/standards-date-modified/standards/) and verify that "Updated September 12, 2024" is shown.
2. Do an "inspect element" on the "Updated September 12, 2024" and verify that the `datetime` attribute of the `<time>` element is `datetime="2024-09-12 00:00:00+00:00"`
3. Repeat steps 1 & 2 on a pending standard page such as [HTML Page Title](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/standards-date-modified/standards/html-page-title/)
4. Repeat steps 1 & 2 on a standard page that is a status other than pending such as [Site search](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/standards-date-modified/standards/site-search-draft/). Our template for each unique standard page has conditional logic so it's helpful to check standards in two different statuses in steps 3 & 4.
