### PR TITLE
Cleanup items

### DIFF
--- a/_includes/status/draft.html
+++ b/_includes/status/draft.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters bg-base-lightest padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>

--- a/_includes/status/draft.html
+++ b/_includes/status/draft.html
@@ -1,4 +1,4 @@
-<div class="usa-step-indicator usa-step-indicator--counters outline-1px padding-2" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters padding-2" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
       <span class="usa-step-indicator__segment-label">Research <span class="usa-sr-only">completed</span></span>

--- a/styles/overrides/_hero.scss
+++ b/styles/overrides/_hero.scss
@@ -1,3 +1,0 @@
-.usa-hero {
-  background-image: $theme-hero-image !important;
-}

--- a/styles/overrides/_usa-step-indicator.scss
+++ b/styles/overrides/_usa-step-indicator.scss
@@ -1,0 +1,3 @@
+.usa-step-indicator--counters .usa-step-indicator__segment:before, .usa-step-indicator--counters-sm .usa-step-indicator__segment:before {
+  box-shadow: none;
+}

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1,7 +1,11 @@
-// Global variables
+/*---------------------------------------------------------
+Global variables
+----------------------------------------------------------*/
 $default-max-width: "widescreen";
 
-// USWDS settings
+/*---------------------------------------------------------
+USWDS Settings
+----------------------------------------------------------*/
 @use "uswds-core" as * with (
   $theme-show-notifications: false,
   $theme-font-path: "../node_modules/@uswds/uswds/dist/fonts",
@@ -16,4 +20,12 @@ $default-max-width: "widescreen";
   $theme-site-alert-max-width: $default-max-width
 );
 
+/*---------------------------------------------------------
+USWDS Source
+----------------------------------------------------------*/
 @forward "uswds";
+
+/*---------------------------------------------------------
+Custom styling
+----------------------------------------------------------*/
+@forward "overrides/_usa-step-indicator.scss";


### PR DESCRIPTION
## Context
* Remove `outline-1px` on the Draft component that was missed from #194 
* Remove the white `box-shadow` property from the USWDS usa-step indicator component that appears on each standard page

## How to verify this change
Pick one standard in each of our current three statuses (pending, research, draft) and verify that the white outline that was previously around each step number is now gone. On the site search standard (draft status) the 1 pixel outline should be gone as well.

* [HTML Page title](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/cleanup/standards/html-page-title/) (Pending status)
* [Contact](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/cleanup/standards/contact-research/) (Research status)
* [Site search](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/cleanup/standards/site-search-draft/) (Draft status)

Federal government banner, Meta page description, and content timeliness indicator don't need to be checked because they all share a status with one of the standards linked above.


