### PR TITLE
Test adding context for the M-23 categories

### DIFF
--- a/standards/banner.md
+++ b/standards/banner.md
@@ -53,6 +53,6 @@ Follow the current [U.S. Web Design System (USWDS) guidance on the banner compon
 
 ## Read more
 
-- U.S. Web Design System (USWDS) guidance on the banner component](https://designsystem.digital.gov/components/banner)
+- [U.S. Web Design System (USWDS) guidance on the banner component](https://designsystem.digital.gov/components/banner)
 - [OMB memo on Delivering a Digital-First Public Experience: Consistent Visual Design and Agency Brand Identity](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=2.%20Consistent%20Visual%20Design%20and%20Agency%20Brand%20Identity)
 

--- a/standards/banner.md
+++ b/standards/banner.md
@@ -53,9 +53,6 @@ Follow the current [U.S. Web Design System (USWDS) guidance on the banner compon
 
 ## Read more
 
-[USWDS community](https://designsystem.digital.gov/about/community/)
-
-## Category
-
-Consistent visual design and agency brand identity
+- U.S. Web Design System (USWDS) guidance on the banner component](https://designsystem.digital.gov/components/banner
+- [OMB memo on Delivering a Digital-First Public Experience: Consistent Visual Design and Agency Brand Identity](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=2.%20Consistent%20Visual%20Design%20and%20Agency%20Brand%20Identity)
 

--- a/standards/banner.md
+++ b/standards/banner.md
@@ -53,6 +53,6 @@ Follow the current [U.S. Web Design System (USWDS) guidance on the banner compon
 
 ## Read more
 
-- U.S. Web Design System (USWDS) guidance on the banner component](https://designsystem.digital.gov/components/banner
+- U.S. Web Design System (USWDS) guidance on the banner component](https://designsystem.digital.gov/components/banner)
 - [OMB memo on Delivering a Digital-First Public Experience: Consistent Visual Design and Agency Brand Identity](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=2.%20Consistent%20Visual%20Design%20and%20Agency%20Brand%20Identity)
 

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -44,7 +44,3 @@ If you have research findings to share let us know at website.standards@gsa.gov 
 ## Read more
 
 - [Nielsen/Norman 2019 report on contact pages](https://www.nngroup.com/articles/contact-us-pages/)
-
-## Category
-
-Information and services that are discoverable and optimized for search

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -35,6 +35,5 @@ We’re researching this potential standard. Research questions include:
 If you have research findings to share let us know at website.standards@gsa.gov or [join a discussion on Github about content timeliness](https://github.com/GSA-TTS/federal-website-standards/discussions/188).
 
 ## Read more
-
 - [Use clear, unambiguous formatting and punctuation (Web Accessibility Initiative)](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o3p06-format-punctuation/#examples)
 - [Express dates and times in a clear and unambiguous way (Google developer documentation)](https://developers.google.com/style/dates-times)

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -35,5 +35,6 @@ We’re researching this potential standard. Research questions include:
 If you have research findings to share let us know at website.standards@gsa.gov or [join a discussion on Github about content timeliness](https://github.com/GSA-TTS/federal-website-standards/discussions/188).
 
 ## Read more
+
 - [Use clear, unambiguous formatting and punctuation (Web Accessibility Initiative)](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o3p06-format-punctuation/#examples)
 - [Express dates and times in a clear and unambiguous way (Google developer documentation)](https://developers.google.com/style/dates-times)

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -38,8 +38,3 @@ If you have research findings to share let us know at website.standards@gsa.gov 
 
 - [Use clear, unambiguous formatting and punctuation (Web Accessibility Initiative)](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o3p06-format-punctuation/#examples)
 - [Express dates and times in a clear and unambiguous way (Google developer documentation)](https://developers.google.com/style/dates-times)
-
-
-## Category
-
-Content that is authoritative and easy to understand

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -56,7 +56,7 @@ These examples show the HTML code for HTML page titles.
 - [How title links in Google Search are created](https://developers.google.com/search/docs/appearance/title-link#how-title-links-in-google-search-are-created)
 - [About the title element (MDN web docs)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
 
-## Category
+## Digital experience category
 
-Information and services that are discoverable and optimized for search
+[Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) (OMB M-23-22: Delivering a Digital-First Public Experience)
 

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -55,8 +55,5 @@ These examples show the HTML code for HTML page titles.
 - [WCAG page titled success criterion](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)
 - [How title links in Google Search are created](https://developers.google.com/search/docs/appearance/title-link#how-title-links-in-google-search-are-created)
 - [About the title element (MDN web docs)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
-
-## Digital experience category
-
-[Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) (OMB M-23-22: Delivering a Digital-First Public Experience)
+- [OMB M-23-22: Delivering a Digital-First Public Experience - Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 
 

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -55,5 +55,5 @@ These examples show the HTML code for HTML page titles.
 - [WCAG page titled success criterion](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html)
 - [How title links in Google Search are created](https://developers.google.com/search/docs/appearance/title-link#how-title-links-in-google-search-are-created)
 - [About the title element (MDN web docs)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
-- [OMB M-23-22: Delivering a Digital-First Public Experience - Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 
+- [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 
 

--- a/standards/meta-page-description.md
+++ b/standards/meta-page-description.md
@@ -53,7 +53,5 @@ These examples show the HTML code for meta page descriptions.
 - [Google's best practices for quality meta descriptions](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions)
 - [USA.gov’s tips for using meta descriptions](https://blog.usa.gov/three-tips-for-using-meta-descriptions)
 - [Search.gov’s guidance for descriptions](https://search.gov/indexing/metadata.html#description)
+- [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search)
 
-## Category
-
-Information and services that are discoverable and optimized for search

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -45,7 +45,4 @@ Public-facing websites of executive branch federal agencies
 
 - [Get started with Search.gov](https://search.gov/get-started/)
 - [An introduction to search from digital.gov](https://digital.gov/resources/an-introduction-to-search/)
-
-## Category
-
-Information and services that are discoverable and optimized for search
+- [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 


### PR DESCRIPTION
- Removed the category field
- Added M-23 category links to the "Read more" for the pending and draft standards

For now, I think we should add the M-23 category link to the "Read more."  We can add the category field back when we can make the clickable and provide more context on category landing pages. 