### PR TITLE
Remove sitewide noindex

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -5,10 +5,8 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
 <section class="usa-hero">
   <div class="grid-container">
     <div class="usa-hero__callout">
-      <h1 class="usa-hero__heading"><span class="usa-hero__heading--alt">Hero callout:</span>Bring attention to a project priority
-      </h1>
-      <p>Support the callout with some short explanatory text. You don’t need more than a couple of sentences.</p>
-      <a class="usa-button" href="javascript:void(0)">Call to action</a>
+      <h1 class="usa-hero__heading">Deliver consistent, digital-first experiences for the public</h1>
+      <a class="usa-button" href="/standards">View the Standards</a>
     </div>
   </div>
 </section>

--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -16,6 +16,10 @@ The home page uses wide.html layout, since it extends full width of page
 
   {% include "menu.html" primary_navigation: site.primary_navigation secondary_navigation: site.secondary_navigation %}
 
+  {% if permalink == '/' %}
+    {% include "hero.html" %}
+  {% endif %}
+
   {{ content }}
 
   {% include "identifier.html" %}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -8,7 +8,7 @@ to modify some of the meta-data for the site, this is the place to do it.
     ================================================== -->
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="robots" content="noindex, nofollow" />
+  <meta name="robots" content="nofollow" />
   <!-- Mobile Specific Metas
     ================================================== -->
   <meta name="HandheldFriendly" content="True" />

--- a/index.md
+++ b/index.md
@@ -1,7 +1,6 @@
 ---
 permalink: /
 layout: layouts/page
-title: Deliver consistent, digital-first experiences for the public
 description: Federal website standards will help agencies provide high-quality, consistent experiences for everyone. Comply with standards to improve your federal site.
 ---
 

--- a/styles/overrides/_hero.scss
+++ b/styles/overrides/_hero.scss
@@ -1,0 +1,17 @@
+@use 'uswds-core' as *;
+
+.usa-hero {
+  @include u-bg('primary-light');
+  background-image: none;
+
+  &__callout {
+    @include u-bg('primary-light');
+    max-width: 30rem;
+  }
+
+  &__heading {
+    color: white;
+    font-weight: 400;
+    line-height: 1.4;
+  }
+}

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -29,3 +29,4 @@ USWDS Source
 Custom styling
 ----------------------------------------------------------*/
 @forward "overrides/_usa-step-indicator.scss";
+@forward "overrides/_hero.scss";


### PR DESCRIPTION
## Context
For implementing Search.gov they need to index our pages but we currently have a sitewide `noindex` setting for robots which prevents any of our pages from being scanned.

## Description
<!-- Provide a description of how you accomplished the task. What changed? If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. -->

## How to verify this change
* Visit the preview URL and inspect the page source, do a `CMD+F` (Mac) or `CTRL+F` (Windows) enter `name="robots"`
* Verify that the found result reads `<meta name="robots" content="nofollow" />`
