### PR TITLE
Remove sitewide noindex

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -8,7 +8,7 @@ to modify some of the meta-data for the site, this is the place to do it.
     ================================================== -->
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="robots" content="noindex, nofollow" />
+  <meta name="robots" content="nofollow" />
   <!-- Mobile Specific Metas
     ================================================== -->
   <meta name="HandheldFriendly" content="True" />


### PR DESCRIPTION
## Context
For implementing Search.gov they need to index our pages but we currently have a sitewide `noindex` setting for robots which prevents any of our pages from being scanned.

## Description
<!-- Provide a description of how you accomplished the task. What changed? If you have made changes to external services, need to add additional values to the job settings, or need to add something new to the database, explain it here. -->

## How to verify this change
* [Visit the preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/fix-robots/) and inspect the page source, do a `CMD+F` (Mac) or `CTRL+F` (Windows) enter `name="robots"`
* Verify that the found result reads `<meta name="robots" content="nofollow" />`