### PR TITLE
Add compliance date for pending standards

### DIFF
--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -16,6 +16,6 @@
 
   <div class="margin-top-4">
     <p class="desktop:display-none text-bold">Pending</p>
-    <p>This will become a standard after a period of time. Agencies should plan to implement this standard.</p>
+    <p>Agencies should plan to implement this standard. Compliance will be required by September 26, 2025.</p>
   </div>
 </div>


### PR DESCRIPTION
The pending standards will launch with a compliance date that is one year from the launch date. This PR adds a compliance date for the pending standards to the include file for the pending status.

[Preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/add-compliance-date/standards/html-page-title/)