### PR TITLE
Update to USWDS 3.8

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
     )
     // For all the remaining anchors, add the external link class
     .forEach((anchor) => {
-      anchor.className = [anchor.className, 'usa-link--external'].join(' ')
+      anchor.className = [anchor.className, 'usa-link--external'].join(' ').trim();
     })
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "license": "CC0-1.0",
       "dependencies": {
-        "@uswds/uswds": "3.1.0"
+        "@uswds/uswds": "3.8.0"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -1702,12 +1702,12 @@
       "dev": true
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.1.0.tgz",
-      "integrity": "sha512-6XTeaQD/ipc3x4713mud4Rrr+lRc4nJ1Qw5Oy35dbVEXuKr7DjN4EBoAkbze9OoV0UdmAIvoxolBF/UcpFVKOg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.0.tgz",
+      "integrity": "sha512-rMwCXe/u4HGkfskvS1Iuabapi/EXku3ChaIFW7y/dUhc7R1TXQhbbfp8YXEjmXPF0yqJnv9T08WPgS0fQqWZ8w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "classlist-polyfill": "1.0.3",
-        "domready": "1.0.8",
+        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -2307,9 +2307,10 @@
       }
     },
     "node_modules/classlist-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.0.3.tgz",
-      "integrity": "sha512-bDLDUsSg5LYFWsc2hphtG6ulyaCFSupdEBU3wxNECKWHnyPVvY8EB9Wbt9DzWkstWclFZhDaZK/VnEK/DmqE/Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==",
+      "license": "Unlicense"
     },
     "node_modules/cliui": {
       "version": "5.0.0",
@@ -2819,11 +2820,6 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
-    },
-    "node_modules/domready": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-      "integrity": "sha512-uIzsOJUNk+AdGE9a6VDeessoMCzF8RrZvJCX/W8QtyfgdR6Uofn/MvRonih3OtCO79b2VDzDOymuiABrQ4z3XA=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
-    "@uswds/uswds": "3.1.0"
+    "@uswds/uswds": "3.8.0"
   }
 }


### PR DESCRIPTION
## Context
@michelle-rago found an issue on the content timeliness standard page where the bullet points for each `<li>` were rendering next to the second line of link text instead of the top. This PR fixes the issue.

## Description
I traced this down to an odd behavior of the `usa-link--external` class. I tried to create a Codepen example to post in the USWDS channel but noticed I couldn't duplicate the behavior. The Codepen template that I maintain currently has USWDS 3.7.1 which made me wonder if updating our USWDS version from 3.1 to 3.8 would take care of the problem and it seems like it does.

## How to verify this change
1. Visit the [content timeliness standard pages](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/uswds-upgrade/standards/content-timeliness-indicator-research/#read-more) "Read more" section and look at the two links, make sure there are no visual oddities with the bullet points like how they previously shifted down to line up with the second line of text.
2. Look around the rest of the site for anything that sticks out visually since this a change to the USWDS version
