### PR TITLE
Add tabindex=-1 to the permalink anchor element

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -101,6 +101,11 @@ module.exports = function (config) {
       class: 'font-heading-lg text-primary-light hover:text-primary',
       symbol: `<svg class="usa-icon" aria-hidden="true" role="img"><use xlink:href="#svg-link"></use></svg>`,
       level: [1, 2, 3, 4],
+      renderAttrs: _ => {
+        return {
+          'tabindex': -1
+        }
+      }
     }),
     slugify: config.getFilter('slug'),
   });


### PR DESCRIPTION
## Description
Sets `tabindex="-1"` on the permalink anchor elements added by our `markdown-it-anchor` plugin.

## Context
We use the `markdown-it-anchor` plugin to render permalink anchor elements and a link SVG onto our header elements. We tell the plugin to add aria-hidden so that the anchors are removed from screen readers and other assitive tech. There's a WCAG rule that says any element with aria-hidden should also be removed from the list of focuasable elements. One way to remove an element from the focusability list is to add the tabindex=-1 property which is what this commit does.

See [this link from Deque University](https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus?application=webdriverjs) for specifics.

This was flagged by our Cloud.gov pages axe/WCAG accessibility report

## How to verify this change
1. Visit any page with header elements present, here's a selection: 
2. Do an inspect element on the header and you'll see an anchor element inside. Look at the properties of this anchor element and you should find `tabindex="-1"`. As an example, here's a full header element from the content timeliness standard pages "Research questions" section:

```HTML
<!-- NB: You're looking for the tabindex property on the anchor <a> element, not the one on the header/h2 -->
<h2 id="research-questions" tabindex="-1">
  Research questions 
  <a class="font-heading-lg text-primary-light hover:text-primary" href="#research-questions" aria-hidden="true" tabindex="-1">
    <svg class="usa-icon" aria-hidden="true" role="img"><use xlink:href="#svg-link"></use></svg>
  </a>
</h2>
```
