### PR TITLE
Add usa-prose to the standards index page

### DIFF
--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -9,7 +9,9 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   <h1 class="font-heading-2xl"> {{ title }} </h1>
 {% endif %}
  
-Federal website standards are evidence-based actions that will help agencies deliver high-quality, consistent digital experiences for the public. This page includes pending standards that will be required and potential standards that are in development so you can follow their progress. 
+<div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
+  <p>Federal website standards are evidence-based actions that will help agencies deliver high-quality, consistent digital experiences for the public. This page includes pending standards that will be required and potential standards that are in development so you can follow their progress.</p>
+</div>
 
 <h2 class="font-heading-xl padding-top-6">Pending standards</h2>
 

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -5,6 +5,7 @@ layout: layouts/page-columns
 This template uses the USWDS card component.
 See https://designsystem.digital.gov/components/card/#when-to-use-the-card-component
 {% endcomment %}
+
 {% if title %}
   <h1 class="font-heading-2xl"> {{ title }} </h1>
 {% endif %}

--- a/_includes/layouts/page-columns.html
+++ b/_includes/layouts/page-columns.html
@@ -6,7 +6,7 @@ layout: layouts/default
 This template is for a single page that does not have a date associated with it. For example, an about page.
 {% endcomment %}
 
-<div class="usa-layout-docs usa-section">
+<div class="usa-layout-docs usa-section usa-prose">
   <div class="grid-container">
       {{ content }}
   </div>


### PR DESCRIPTION
## Description
The text below the "Standards" heading lacked the `usa-prose` class that text (especially those in `<p>` tags) elsewhere had applied. This made the text on the standards index page flow all the way across the page instead of wrapping. This PR applies `usa-prose` to this text as well as wrapping it in a `<p>` tag.

## How to verify this change
1. Visit the [standards index page](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/standards-usa-prose/standards/) and observe that the text that begins with "Federal website standards are evidence-based..." is not flowing all the way across the width of the page but instead it wraps.
2. Inspect element on the text and verify that it's inside of `p` tags and that `usa-prose` is applied to its parent`div`
