### PR TITLE
Revert max-width of grid-container back to normal

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1,9 +1,4 @@
 /*---------------------------------------------------------
-Global variables
-----------------------------------------------------------*/
-$default-max-width: "widescreen";
-
-/*---------------------------------------------------------
 USWDS Settings
 ----------------------------------------------------------*/
 @use "uswds-core" as * with (
@@ -12,12 +7,6 @@ USWDS Settings
   $theme-image-path: "../node_modules/@uswds/uswds/dist/img",
   $theme-font-type-sans: "public-sans",
   $theme-hero-image: "../_img/hero.png",
-  $theme-grid-container-max-width: $default-max-width,
-  $theme-banner-max-width: $default-max-width,
-  $theme-footer-max-width: $default-max-width,
-  $theme-header-max-width: $default-max-width,
-  $theme-identifier-max-width: $default-max-width,
-  $theme-site-alert-max-width: $default-max-width
 );
 
 /*---------------------------------------------------------


### PR DESCRIPTION
We were using widescreen as our default max container width which is 87.5rem. This reverts back to the USWDS default grid-container max-width which is 64rem in order to match the style in place on digital.gov

## How to verify this change
1. [Visit the preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/update-margins/) and you should immediately notice that the content of the site is taking up less width than before and the margins without content to the left and right are larger. This should match what's on digital.gov.
2. Emulate a tablet and mobile device and verify things look good there too