### PR TITLE
Link to GSA website in the footer

### DIFF
--- a/_includes/identifier.html
+++ b/_includes/identifier.html
@@ -12,7 +12,7 @@ See https://designsystem.digital.gov/components/identifier/#when-to-use-the-iden
       >
       <div class="usa-identifier__container">
         <div class="usa-identifier__logos">
-          <a href="javascript:void(0);" class="usa-identifier__logo">
+          <a href="https://gsa.gov" class="usa-identifier__logo">
           {% image_with_class  "./_img/gsa-logo.svg" "usa-identifier__logo-img" "GSA Logo" "false" %}
           </a>
         </div>


### PR DESCRIPTION
## Description
I noticed the GSA logo in use on Digital.gov links to the GSA website so I updated our logo to do the same.

## How to verify this change
1. [Visit the preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/update-gsa-footer-link/), scroll to the footer and verify that clicking the GSA logo takes you to the GSA website.
