### PR TITLE
Replace active link color red with uswds primary

### DIFF
--- a/styles/overrides/_global.scss
+++ b/styles/overrides/_global.scss
@@ -1,3 +1,9 @@
+@use 'uswds-core' as *;
+
 h1, h2, h3, h4 {
   text-wrap: balance;
+}
+
+a:active {
+  color: color('primary');
 }


### PR DESCRIPTION
## Context
Fixes #159 

## Description
The active link color was red, this updates it to be "primary" from USWDS which is #005ea2 all across the site.

## How to verify this change
1. [Visit the preview ](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/active-link-color/)and toggle any link that appears in the body text to an active status and verify that it's no longer red. #159 has a video showing the previous behavior.
