### PR TITLE
Make the page title appear before the site title in the HTML page title

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,7 +16,7 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Title and meta description
     ================================================== -->
-  <title>{{ site.title }} | {{ title }}</title>
+  <title>{{ title }} | {{ site.title }}</title>
   <meta property="og:title" content="{{ title }} | {{ site.title }}" />
   <meta name="description" content="{{ description }}" />
   <meta property="og:description" content="{{ description }}" />

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -16,7 +16,11 @@ to modify some of the meta-data for the site, this is the place to do it.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Title and meta description
     ================================================== -->
-  <title>{{ title }} | {{ site.title }}</title>
+  {% if permalink == '/' %}
+    <title>Federal website standards for executive branch federal agencies</title>
+  {% else %}
+    <title>{{ title }} | {{ site.title }}</title>
+  {% endif %}
   <meta property="og:title" content="{{ title }} | {{ site.title }}" />
   <meta name="description" content="{{ description }}" />
   <meta property="og:description" content="{{ description }}" />


### PR DESCRIPTION
The page title should appear before the site title in the HTML page title. For example, for the About page, the HTML page title should be "About federal website standards | Federal website standards."

@caleywoods I'm not sure where or how (else) to make this change.