### PR TITLE
Use "Published" for pending standards instead of updated

### DIFF
--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -40,7 +40,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
       <div class="usa-card__footer">
-        Updated <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+        Published <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
       </div>

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -17,7 +17,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
 </div>
 
 <h2 class="font-heading-xl padding-top-6">Pending standards</h2>
-<p>Pending standards have been finalized and will be required after a specified period of time. Agencies can begin working to comply with pending standards.</p>
+<p>Pending standards have been finalized. They will be required after a specified period of time following their initial publication. Agencies can begin working to comply with pending standards.</p>
 
 
 <ul class="usa-card-group">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -17,7 +17,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
 </div>
 
 <h2 class="font-heading-xl padding-top-6">Pending standards</h2>
-<p>Pending standards have been finalized. They will be required after a specified period of time following their initial publication. Agencies can begin working to comply with pending standards.</p>
+<p>Pending standards have been finalized and will be required after a specified period of time following their initial publication. Agencies can begin working to comply with pending standards.</p>
 
 
 <ul class="usa-card-group">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -40,7 +40,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
       <div class="usa-card__footer">
-        Published <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+        Published: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
       </div>
@@ -74,7 +74,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
       <div class="usa-card__footer">
-        Updated <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+        Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
       </div>
@@ -109,7 +109,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
       <div class="usa-card__footer">
-        Updated <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+        Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
       </div>

--- a/about/index.md
+++ b/about/index.md
@@ -17,7 +17,7 @@ We’ll publish information about standards as they're being developed. Each sta
 
 - **Research**: This standard is being researched with the public, federal agencies, and other stakeholders.
 - **Draft**: This standard has been drafted and is being shared with federal agencies and other stakeholders.
-- **Pending**: This standard has been finalized and will be required after a specified period of time. Agencies should plan to comply with this standard.
+- **Pending**: This standard has been finalized. This standard will be required after a specified period of time following its initial publication. Agencies can begin working to comply with pending standards.
 - **Required**: Federal agencies must comply with this standard.
 
 ## How the standards are developed

--- a/about/index.md
+++ b/about/index.md
@@ -17,7 +17,7 @@ We’ll publish information about standards as they're being developed. Each sta
 
 - **Research**: This standard is being researched with the public, federal agencies, and other stakeholders.
 - **Draft**: This standard has been drafted and is being shared with federal agencies and other stakeholders.
-- **Pending**: This standard has been finalized. This standard will be required after a specified period of time following its initial publication. Agencies can begin working to comply with pending standards.
+- **Pending**: This standard has been finalized and will be required after a specified period of time following its initial publication. Agencies can begin working to comply with pending standards.
 - **Required**: Federal agencies must comply with this standard.
 
 ## How the standards are developed

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ Federal agencies are required to comply with website standards per the [21st Cen
 ## Actions for federal agencies to take{.checklist}
 - Review the [standards](standards).
 - Consider how the standards apply to your public-facing websites.
-- Plan to evaluate your compliance with the [three pending standards](standards). Pending standards have been finalized and will be required after a specified period of time.
+- Plan to evaluate your compliance with the [three pending standards](standards). Pending standards have been finalized and will be required after a specified period of time following their initial publication. Agencies can begin working to comply with pending standards.
 
 ## Standards will be released incrementally
 

--- a/standards/banner.md
+++ b/standards/banner.md
@@ -8,7 +8,7 @@ status: Pending
 description: The federal government banner identifies official federal government sites. Learn how to implement the banner on your federal government site.
 surveyLink: 
 eleventyExcludeFromCollections: false
-date: "2024-09-12"
+date: "2024-09-26"
 ---
 
 ## Status

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -8,7 +8,7 @@ why: A descriptive page title is important for accessibility and discoverability
 status: Pending
 description: A descriptive and unique page title is important for accessibility and discoverability. Learn how to create quality HTML page titles for your federal government site.
 surveyLink: 
-date: "2024-09-12"
+date: "2024-09-26"
 ---
 
 ## Status

--- a/standards/meta-page-description.md
+++ b/standards/meta-page-description.md
@@ -8,7 +8,7 @@ why: The meta description supports accessibility and discoverability.
 status: Pending
 description: A descriptive and unique meta page description is important for accessibility and discoverability. Learn how to create quality meta page descriptions for your federal government site.
 surveyLink: 
-date: "2024-09-12"
+date: "2024-09-26"
 ---
 
 ## Status


### PR DESCRIPTION
Test using a "Published" date for pending standards to support the notion of finality.