### PR TITLE
Add permalink to 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 ---
 layout: layouts/page
+permalink: 404.html
 ---
 
 <div class="grid-row grid-gap">


### PR DESCRIPTION
## Description
This adds a permalink to the 404 page so that Eleventy builds the page at `_site/404.html` instead of `_site/404/index.html`. Cloud.gov pages will serve `404.html` for "not found" requests but currently we have the default Cloud.gov pages 404 shown because we're not providing a `404.html`

## How to verify this change
This can't be verified on a preview branch, Cloud.gov will only serve a custom 404 page on production domains. Once this is merged you can verify by trying any "bad" URL such as https://standards.digital.gov/this-page-doesnt-exist
