### PR TITLE
More visual tweaks

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@ official government website
 {% endcomment %}
 
 <div class="page-landing-page layout-demo ">
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  <a class="usa-skipnav" href="#hero-callout">Skip to main content</a>
   <section
     class="usa-banner"
     aria-label="Official website of the United States government"

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -5,7 +5,7 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
 <section class="usa-hero">
   <div class="grid-container">
     <div class="usa-hero__callout">
-      <h1 class="usa-hero__heading">Deliver consistent, digital-first experiences for the public</h1>
+      <h1 class="usa-hero__heading" id="hero-callout">Deliver consistent, digital-first experiences for the public</h1>
       <a class="usa-button" href="standards">View the federal website standards</a>
     </div>
   </div>

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -13,22 +13,8 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
 <div class="usa-layout-docs__main usa-prose">
   <p>Federal website standards will help agencies provide high-quality, consistent digital experiences for everyone. The standards cover visual and technical elements that reflect user experience best practices.</p>
   <p>We’ll publish information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
-<div class="usa-step-indicator usa-step-indicator--counters padding-y-2 display-none tablet:display-block" aria-label="progress">
-  <ol class="usa-step-indicator__segments">
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>
-    </li>
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Draft<span class="usa-sr-only">completed</span></span>
-    </li>
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Pending<span class="usa-sr-only">completed</span></span>
-    </li>
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Required<span class="usa-sr-only">completed</span></span>
-    </li>
-  </ol>
-</div>
+
+  {% include "_includes/step-indicator.html" %}
 
 <h2 class="font-heading-xl padding-top-1">Required</h2>
 <p>Currently, there are no required standards.</p>

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -13,7 +13,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
 <div class="usa-layout-docs__main usa-prose">
   <p>Federal website standards will help agencies provide high-quality, consistent digital experiences for everyone. The standards cover visual and technical elements that reflect user experience best practices.</p>
   <p>We’ll publish information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
-<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
+<div class="usa-step-indicator usa-step-indicator--counters padding-y-2 display-none tablet:display-block" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
       <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -40,7 +40,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Why: </strong>{{ standard.data.why }}</p>
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
-      <div class="usa-card__footer">
+      <div class="usa-card__footer text-italic">
         Published: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
@@ -72,7 +72,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Why: </strong>{{ standard.data.why }}</p>
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
-      <div class="usa-card__footer">
+      <div class="usa-card__footer text-italic">
         Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
@@ -105,7 +105,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
         <p><strong>Why: </strong>{{ standard.data.why }}</p>
         <p><strong>Status: </strong>{{ standard.data.status }}</p>
       </div>
-      <div class="usa-card__footer">
+      <div class="usa-card__footer text-italic">
         Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>

--- a/_includes/step-indicator.html
+++ b/_includes/step-indicator.html
@@ -1,0 +1,16 @@
+<div class="usa-step-indicator usa-step-indicator--counters padding-y-2 display-none tablet:display-block" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
+      <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
+      <span class="usa-step-indicator__segment-label">Draft<span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
+      <span class="usa-step-indicator__segment-label">Pending<span class="usa-sr-only">completed</span></span>
+    </li>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
+      <span class="usa-step-indicator__segment-label">Required<span class="usa-sr-only">completed</span></span>
+    </li>
+  </ol>
+</div>

--- a/about/index.md
+++ b/about/index.md
@@ -15,22 +15,7 @@ Federal agencies are required to comply with website standards per the [21st Cen
 
 We’ll publish information about standards as they're being developed. Each standard will have a status to indicate where it is in the process. 
 
-<div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
-  <ol class="usa-step-indicator__segments">
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Research<span class="usa-sr-only">completed</span></span>
-    </li>
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Draft<span class="usa-sr-only">completed</span></span>
-    </li>
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Pending<span class="usa-sr-only">completed</span></span>
-    </li>
-    <li class="usa-step-indicator__segment usa-step-indicator__segment--current">
-      <span class="usa-step-indicator__segment-label">Required<span class="usa-sr-only">completed</span></span>
-    </li>
-  </ol>
-</div>
+{% include "_includes/step-indicator.html" %}
 
 - **Research**: This standard is being researched with the public, federal agencies, and other stakeholders.
 - **Draft**: This standard has been drafted and is being shared with federal agencies and other stakeholders.

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -40,8 +40,3 @@ CHECKLIST
     padding-left: units(3);
   }
 }
-
-// This style gets overriden by other class overrides. We can fix this here.
-.display-none {
-  display: none !important;
-}


### PR DESCRIPTION
## Context
Doing some remaining visual tweaks.

* Added y-axis padding to the step indicator on the standards overview page and the about page as well as hiding it on mobile, this component was moved into an include as well since it's shown on two separate pages
* Italicize the published/updated date on each standard card

## How to verify this change
1. [Visit the preview](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/cleanup-round-3/) and...

