### PR TITLE
Remove standards card page

### DIFF
--- a/standards/cards.md
+++ b/standards/cards.md
@@ -1,4 +1,0 @@
----
-layout: layouts/cards
-title: List of federal website standards
----


### PR DESCRIPTION
## Context
`standards/cards.html` doesn't seem to be used, verified with @michelle-rago on Slack.
