### PR TITLE
Add a join the conversation include to callout how to give feedback on standards

### DIFF
--- a/_includes/join-the-conversation.html
+++ b/_includes/join-the-conversation.html
@@ -4,6 +4,6 @@
     {% image_with_class "./node_modules/@uswds/uswds/dist/img/usa-icons/comment.svg" "padding-right-1 flex" "" %}
   </div>
   <div class="grid-col">
-    <p>If you have research findings to share, let us know at <a href="mailto:website.standards@gsa.gov">website.standards@gsa.gov</a> or <a href="https://github.com/GSA-TTS/federal-website-standards/discussions/{{ discussion_number }}">join a discussion on GitHub about {{ name }}</a>.</p>
+    <p>If you have feedback to share, let us know at <a href="mailto:website.standards@gsa.gov">website.standards@gsa.gov</a> or <a href="https://github.com/GSA-TTS/federal-website-standards/discussions/{{ discussion_number }}">join a discussion on GitHub about {{ name }}</a>.</p>
   </div>
 </div>

--- a/_includes/join-the-conversation.html
+++ b/_includes/join-the-conversation.html
@@ -1,0 +1,9 @@
+{% assign name = name | default: "this standard" %}
+<div class="grid-row flex-row">
+  <div class="grid-col-auto flex-align-self-center padding-right-1">
+    {% image_with_class "./node_modules/@uswds/uswds/dist/img/usa-icons/comment.svg" "padding-right-1 flex" "" %}
+  </div>
+  <div class="grid-col">
+    <p>If you have research findings to share, let us know at <a href="mailto:website.standards@gsa.gov">website.standards@gsa.gov</a> or <a href="https://github.com/GSA-TTS/federal-website-standards/discussions/{{ discussion_number }}">join a discussion on GitHub about {{ name }}</a>.</p>
+  </div>
+</div>

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -1,7 +1,7 @@
 ---
 layout: layouts/page-single
 tags: standards
-title: Agency contact page
+title: Contact page
 category:
   ["Information and services that are discoverable and optimized for search"]
 why: Contact information that is easily and consistently accessible builds trust and credibility.
@@ -10,7 +10,7 @@ description: A contact page is important for building trust and serving your use
 surveyLink: 
 date: "2024-09-12"
 github_discussion_number: 183
-join_the_conversation_name: agency contact pages
+join_the_conversation_name: contact pages
 ---
 
 ## Status

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -10,7 +10,7 @@ description: A contact page is important for building trust and serving your use
 surveyLink: 
 date: "2024-09-12"
 github_discussion_number: 183
-join_the_conversation_name: agency contact page
+join_the_conversation_name: agency contact pages
 ---
 
 ## Status

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -8,7 +8,7 @@ why: Contact information that is easily and consistently accessible builds trust
 status: Research
 description: A contact page is important for building trust and serving your users. Learn how to create a good contact page for your federal government site.
 surveyLink: 
-date: "2024-09-12"
+date: "2024-09-25"
 github_discussion_number: 183
 join_the_conversation_name: contact pages
 ---

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -9,6 +9,8 @@ status: Research
 description: A contact page is important for building trust and serving your users. Learn how to create a good contact page for your federal government site.
 surveyLink: 
 date: "2024-09-12"
+github_discussion_number: 183
+join_the_conversation_name: contact page
 ---
 
 ## Status
@@ -30,8 +32,7 @@ We’re researching this potential standard. Research questions include:
 - Are users able to find the contact link as easily in the header, footer, or mobile menu?
 - What kind of contact information do users expect to see (at a minimum)?
 
-If you have research findings to share, let us know at website.standards@gsa.gov or [join a discussion on GitHub about contact information](https://github.com/GSA-TTS/federal-website-standards/discussions/183). 
-
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
 
 ## Examples of agency contact pages
 

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -1,7 +1,7 @@
 ---
 layout: layouts/page-single
 tags: standards
-title: Contact
+title: Agency contact page
 category:
   ["Information and services that are discoverable and optimized for search"]
 why: Contact information that is easily and consistently accessible builds trust and credibility.
@@ -10,7 +10,7 @@ description: A contact page is important for building trust and serving your use
 surveyLink: 
 date: "2024-09-12"
 github_discussion_number: 183
-join_the_conversation_name: contact page
+join_the_conversation_name: agency contact page
 ---
 
 ## Status

--- a/standards/contact-research.md
+++ b/standards/contact-research.md
@@ -32,8 +32,6 @@ We’re researching this potential standard. Research questions include:
 - Are users able to find the contact link as easily in the header, footer, or mobile menu?
 - What kind of contact information do users expect to see (at a minimum)?
 
-{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
-
 ## Examples of agency contact pages
 
 - [Small Business Administration contact page](https://www.sba.gov/about-sba/organization/contact-sba)
@@ -41,7 +39,10 @@ We’re researching this potential standard. Research questions include:
 - [Department of Energy contact page](https://www.energy.gov/contact-us)
 - [Office of Personnel Management contact page](https://www.opm.gov/about-us/contact-us/)
 
-
 ## Read more
 
 - [Nielsen/Norman 2019 report on contact pages](https://www.nngroup.com/articles/contact-us-pages/)
+
+## Feedback
+
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -10,7 +10,7 @@ description: Timeliness indicators can increase trust in the currency and accura
 surveyLink: 
 date: "2024-09-24"
 github_discussion_number: 188
-join_the_conversation_name: content timeliness
+join_the_conversation_name: content timeliness indicators
 ---
 
 ## Status

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -34,9 +34,11 @@ We’re researching this potential standard. Research questions include:
 - Do users have preferences on the length of time between updates for certain types of content? 
 - How do users respond to multiple dates (e.g., published and updated)?
 
-{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
-
 ## Read more
 
 - [Use clear, unambiguous formatting and punctuation (Web Accessibility Initiative)](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o3p06-format-punctuation/#examples)
 - [Express dates and times in a clear and unambiguous way (Google developer documentation)](https://developers.google.com/style/dates-times)
+
+## Feedback
+
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -9,6 +9,8 @@ status: Research
 description: Timeliness indicators can increase trust in the currency and accuracy of information. Learn how to add timeliness indicators on your federal government site.
 surveyLink: 
 date: "2024-09-24"
+github_discussion_number: 188
+join_the_conversation_name: content timeliness
 ---
 
 ## Status
@@ -32,7 +34,7 @@ We’re researching this potential standard. Research questions include:
 - Do users have preferences on the length of time between updates for certain types of content? 
 - How do users respond to multiple dates (e.g., published and updated)?
 
-If you have research findings to share, let us know at website.standards@gsa.gov or [join a discussion on GitHub about content timeliness](https://github.com/GSA-TTS/federal-website-standards/discussions/188).
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
 
 ## Read more
 

--- a/standards/content-timeliness-indicator-research.md
+++ b/standards/content-timeliness-indicator-research.md
@@ -8,7 +8,7 @@ why: Timeliness indicators can increase user trust in the currency and accuracy 
 status: Research
 description: Timeliness indicators can increase trust in the currency and accuracy of information. Learn how to add timeliness indicators on your federal government site.
 surveyLink: 
-date: "2024-09-24"
+date: "2024-09-25"
 github_discussion_number: 188
 join_the_conversation_name: content timeliness indicators
 ---

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -10,6 +10,8 @@ description: Search functionality is an expected feature for websites and digita
 surveyLink: 
 pageFlowSection:
 date: "2024-09-12"
+github_discussion_number: 233
+join_the_conversation_name: site search
 ---
 
 ## Status
@@ -42,9 +44,9 @@ Public-facing websites of executive branch federal agencies
 - Follow the [U.S. Web Design System (USWDS) guidance on search](https://designsystem.digital.gov/components/search/).
 - The search function should be a site-wide global search. When appropriate for your users, the search feature could search subsets of content (e.g., help, blog, videos).
 
-
 ## Read more
 
 - [Get started with Search.gov](https://search.gov/get-started/)
 - [An introduction to search from Digital.gov](https://digital.gov/resources/an-introduction-to-search/)
 - [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -9,7 +9,7 @@ status: Draft
 description: Search functionality is an expected feature for websites and digital services. Learn how to add a search capability to your federal government site.
 surveyLink: 
 pageFlowSection:
-date: "2024-09-12"
+date: "2024-09-25"
 github_discussion_number: 233
 join_the_conversation_name: site search
 ---

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -17,7 +17,6 @@ join_the_conversation_name: site search
 ## Status
 
 {% include "_includes/status/draft.html" %}
-{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
 
 ## Standard
 
@@ -47,4 +46,8 @@ Public-facing websites of executive branch federal agencies
 
 - [Get started with Search.gov](https://search.gov/get-started/)
 - [An introduction to search from Digital.gov](https://digital.gov/resources/an-introduction-to-search/)
-- [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 
+- [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search)
+
+## Feedback
+
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -18,7 +18,7 @@ join_the_conversation_name: site search
 
 {% include "_includes/status/draft.html" %}
 
-Email us if you have feedback at website.standards@gsa.gov or [join a discussion on GitHub about site search](https://github.com/GSA-TTS/federal-website-standards/discussions/233).
+{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
 
 ## Standard
 
@@ -49,4 +49,3 @@ Public-facing websites of executive branch federal agencies
 - [Get started with Search.gov](https://search.gov/get-started/)
 - [An introduction to search from Digital.gov](https://digital.gov/resources/an-introduction-to-search/)
 - [OMB memo on Delivering a Digital-First Public Experience: Information and services that are discoverable and optimized for search](https://www.whitehouse.gov/omb/management/ofcio/delivering-a-digital-first-public-experience/#IIIA:~:text=4.%20Information%20and%20Services%20That%20Are%20Discoverable%20and%20Optimized%20for%20Search) 
-{% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}

--- a/standards/site-search-draft.md
+++ b/standards/site-search-draft.md
@@ -17,7 +17,6 @@ join_the_conversation_name: site search
 ## Status
 
 {% include "_includes/status/draft.html" %}
-
 {% include "_includes/join-the-conversation.html" discussion_number: github_discussion_number name: join_the_conversation_name %}
 
 ## Standard


### PR DESCRIPTION
## Context
A few users were looking around for how to give feedback on standards in the useability sessions. This implements an include that shows a USWDS comment icon and text that directs users where to contact us or comment on the GitHub discussion.

## Description
`_includes/join-the-conversation.html` expects two variables to be passed in when it's included named `discussion_number` and `name`. Both of these variables are currently supplied by front matter I added to site search, contact page, and content timeliness but they can be hardcoded in the `include` statement. `discussion_number` is the unique number that GitHub gives to something when you [create a new discussion](https://github.com/GSA-TTS/federal-website-standards/discussions) (it's the number at the end of the discussion URL) and `name` is a value that should hopefully match whatever the discussion name is on GitHub such as "contact page", "content timeliness", or "site search", this variable gets used as part of the link text on the standard page for the "join a discussion on GitHub..." verbiage and should be all lowercase. `name` defaults to "this standard" inside the `join-the-conversation` include in case there's no value given so that the link text can then be "join a discussion on GitHub about this standard" instead of "join a discussion on GitHub about ".

## How to verify this change
1. Visit the [Site search standard](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/join-us-callout/standards/site-search-draft/), verify the include is well...included under the "Read more" section. Verify that the discussion link works and that the "join a discussion on GitHub" link description makes sense
2. Visit the [Contact page standard](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/join-us-callout/standards/contact-research/), verify the include is there under the "Read more" section. Verify that the discussion link works and that the "join a discussion on GitHub" link description makes sense
3. Visit the [Content timeliness standard](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/join-us-callout/standards/content-timeliness-indicator-research/), verify the include is there under the "Read more" section. Verify that the discussion link works and that the "join a discussion on GitHub" link description makes sense
