### PR TITLE
Remove grid-gap-6 causing horizontal scroll

### DIFF
--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -8,7 +8,7 @@ This template is for a single page with meta data. It should feed the page-colum
 
 <div class="usa-layout-docs usa-section">
   <div class="grid-container">
-    <div class="grid-row grid-gap-6">
+    <div class="grid-row">
       {% if sidenav == true %}
       {% include "sidenav.html" %}
       {% endif %}


### PR DESCRIPTION
## Context
Fixes #253 

## Description
`grid-gap-6` seems like it was allowing some horizontal scroll on mobile.

## How to verify this change
1. [Visit an individual standard page](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/fix-standards-pages-mobile/standards/banner/) on the preview, emulate a mobile viewport and check for the ability to scroll horizontally
