### PR TITLE
Add missing title for 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 layout: layouts/page
 permalink: 404.html
+title: Page not found
 ---
 
 <div class="grid-row grid-gap">

--- a/_includes/layouts/page.html
+++ b/_includes/layouts/page.html
@@ -14,7 +14,9 @@ This template is for a single page that does not have a date associated with it.
       {% endif %}
       <div class="usa-layout-docs__main desktop:grid-col-9 usa-prose">
         {% if title %}
-          <h1 class="title"> {{ title }} </h1>
+          {% if permalink != '404.html' %}
+            <h1 class="title"> {{ title }} </h1>
+          {% endif %}
         {% endif %}
         {{ content }}
         {% if summary == true %}


### PR DESCRIPTION
## Context
Should fix #251 

## Description
The 404 page was missing `title` front matter. I've added a check in the layout to exclude the page title from being rendered as an `<h1>` on the 404 page so it doesn't conflict with the content.

## How to verify this change
This is hard to verify that "not found" results other than going directly to the 404 without merging it because Cloud.gov won't show our 404 template on anything other than the production page.
