### PR TITLE
Test adding change history for each standard

### DIFF
--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -32,8 +32,7 @@ This template is for a single page with meta data. It should feed the page-colum
       <span>Last updated&nbsp;</span>
       <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
        {{ page.date | toISOString: 'DDD' }}
-      </time>
-       (<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the change history of this standard</a>.)
+      </time> | <a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the change history of this standard</a>
     </div>
     </div>
 </div>

--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -33,6 +33,7 @@ This template is for a single page with meta data. It should feed the page-colum
       <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
        {{ page.date | toISOString: 'DDD' }}
       </time>
+      (<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the history of this standard</a>)
     </div>
     </div>
 </div>

--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -32,7 +32,8 @@ This template is for a single page with meta data. It should feed the page-colum
       <span>Last updated&nbsp;</span>
       <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
        {{ page.date | toISOString: 'DDD' }}
-      </time> | <a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the change history of this standard</a>
+      </time>
+      <span>&nbsp; | &nbsp;<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the change history of this standard</a></span>
     </div>
     </div>
 </div>

--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -33,7 +33,7 @@ This template is for a single page with meta data. It should feed the page-colum
       <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
        {{ page.date | toISOString: 'DDD' }}
       </time>
-       (<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the history of this standard</a>)
+       (<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the change history of this standard</a>.)
     </div>
     </div>
 </div>

--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -33,7 +33,7 @@ This template is for a single page with meta data. It should feed the page-colum
       <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
        {{ page.date | toISOString: 'DDD' }}
       </time>
-      (<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the history of this standard</a>)
+       (<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the history of this standard</a>)
     </div>
     </div>
 </div>

--- a/_includes/layouts/page-single.html
+++ b/_includes/layouts/page-single.html
@@ -33,7 +33,7 @@ This template is for a single page with meta data. It should feed the page-colum
       <time datetime="{{ page.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
        {{ page.date | toISOString: 'DDD' }}
       </time>
-      <span>&nbsp; | &nbsp;<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">View the change history of this standard</a></span>
+      <span>&nbsp; | &nbsp;<a href="https://github.com/GSA-TTS/federal-website-standards/commits/main/{{ page.inputPath | remove_first: '.' }}">Version history</a></span>
     </div>
     </div>
 </div>


### PR DESCRIPTION
We want to make a change history available for the standards pages (as mentioned in https://github.com/GSA-TTS/federal-website-standards/issues/158). Until something more sophisticated is developed, we can use GitHub's commit history.

[Preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/change-history/standards/meta-page-description/)