### PR TITLE
Move content timeliness to draft phase

### DIFF
--- a/standards/content-timeliness-indicator.md
+++ b/standards/content-timeliness-indicator.md
@@ -3,7 +3,7 @@ layout: layouts/page-single
 tags: standards
 title: Content timeliness indicator
 why: Timeliness indicators can increase user trust in the currency and accuracy of information.
-status: Research
+status: Draft
 description: Timeliness indicators can increase trust in the currency and accuracy of information. Learn how to add timeliness indicators on your federal government site.
 date: "2024-09-25"
 github_discussion_number: 188
@@ -12,7 +12,7 @@ join_the_conversation_name: content timeliness indicators
 
 ## Status
 
-{% include "_includes/status/research.html" %}
+{% include "_includes/status/draft.html" %}
 
 ## Standard
 
@@ -22,14 +22,74 @@ Inform users about the timeliness of content by including the date of publicatio
 
 Timeliness indicators can increase user trust in the currency and accuracy of information.
 
-## Research questions
+## Applies to
 
-We’re researching this potential standard. Research questions include:
+Executive branch agency websites and digital services that are intended for use by the public
 
-- Do users have preferences for the language used (published, updated, or reviewed)? 
-- Should the language be standardized by type of content? 
-- Do users have preferences on the length of time between updates for certain types of content? 
-- How do users respond to multiple dates (e.g., published and updated)?
+## Acceptance criteria
+
+These conditions must be met to comply with this standard.
+
+Include timeliness indicators on the following types of content:
+- News, press releases
+- Announcements, alerts
+- Data, statistics
+- Information that changes every year or information that is likely to change every year
+- Policies, regulations, legal information
+- Health information
+
+## How to implement
+
+These are tips to help you implement this standard.
+
+- **Placement**: Put the timeliness indicator at the top or bottom of the page. Place the indicator in a consistent location on all pages of the same content type.
+- **Format**: Use the full month name followed by the day and year as in this example: `Updated June 27, 2024`. The full month name is clearer than using an abbreviation or only numbers.
+- **When to change the date**: Update the date if the content changes substantively. A substantive change is one that impacts the information in a way that is relevant to your audience.
+- **Language**: Use plain language to specify when content was published, last updated, or last reviewed. Acceptable phrases include:
+  - `Published May 8, 2024`
+  - `Updated June 12, 2024`
+  - `Reviewed July 1, 2024`
+
+### Timeliness indicator options for types of content
+
+Use the most appropriate indicators for the type of content being managed. 
+
+#### News, press releases
+
+- Include a publication date.
+- Add an “Updated” date if the information substantively changed after it was first published. 
+
+#### Announcements, alerts 
+
+- Include a publication date.
+- Add an expiration date if applicable.
+
+#### Data, statistics
+
+- Include a publication date.
+- Add an “Updated” date if the information substantively changed after it was first published.
+- Include the time period covered by the data.
+- Include the time period during which the data was collected if it’s relevant for your audience.
+
+#### Information that is likely to change every year
+
+- Include a publication date on information that changes every year, like tax guidance.
+- Add an “Updated” date if the information substantively changed after it was first published.
+- Add a “Reviewed” date if the information was reviewed after publication or after being updated. For information that is likely to change every year, it’s important to let users know that the information has been reviewed even if there are no substantive changes.
+- Add an effective date and/or an expiration date if applicable.
+
+#### Policies, regulations, legal information
+
+- Include a publication date.
+- Add an “Updated” date if the information substantively changed after it was first published.
+- Add a “Reviewed” date if the information was reviewed after publication or after being updated.
+- Add an effective date and/or an expiration date if applicable.
+
+#### Health information
+
+- Include a publication date.
+- Add an “Updated” date if the information substantively changed after it was first published.
+- Add a “Reviewed” date if the information was reviewed after publication or after being updated.
 
 ## Read more
 

--- a/standards/content-timeliness-indicator.md
+++ b/standards/content-timeliness-indicator.md
@@ -62,7 +62,7 @@ Use the most appropriate indicators for the type of content being managed.
 #### Announcements, alerts 
 
 - Include a publication date.
-- Add an expiration date if applicable.
+- Add an effective date and/or an expiration date if applicable.
 
 #### Data, statistics
 

--- a/standards/content-timeliness-indicator.md
+++ b/standards/content-timeliness-indicator.md
@@ -5,7 +5,7 @@ title: Content timeliness indicator
 why: Timeliness indicators can increase user trust in the currency and accuracy of information.
 status: Draft
 description: Timeliness indicators can increase trust in the currency and accuracy of information. Learn how to add timeliness indicators on your federal government site.
-date: "2024-09-25"
+date: "2024-10-31"
 github_discussion_number: 188
 join_the_conversation_name: content timeliness indicators
 ---

--- a/standards/content-timeliness-indicator.md
+++ b/standards/content-timeliness-indicator.md
@@ -45,7 +45,7 @@ These are tips to help you implement this standard.
 - **Placement**: Put the timeliness indicator at the top or bottom of the page. Place the indicator in a consistent location on all pages of the same content type.
 - **Format**: Use the full month name followed by the day and year as in this example: `Updated June 27, 2024`. The full month name is clearer than using an abbreviation or only numbers.
 - **When to change the date**: Update the date if the content changes substantively. A substantive change is one that impacts the information in a way that is relevant to your audience.
-- **Language**: Use plain language to specify when content was published, last updated, or last reviewed. Acceptable phrases include:
+- **Language**: Use plain language to specify when content was published, last updated, or last reviewed. Recommended phrases include:
   - `Published May 8, 2024`
   - `Updated June 12, 2024`
   - `Reviewed July 1, 2024`


### PR DESCRIPTION
Move content timeliness to draft phase. Align draft standard with internal Google doc and feedback received in agency office hours.