### PR TITLE
Dynamic "comply by" date for pending standards

### DIFF
--- a/_includes/status/pending.html
+++ b/_includes/status/pending.html
@@ -1,3 +1,4 @@
+{% assign date = comply_by_date | default: "September 26th, 2025" %}
 <div class="usa-step-indicator usa-step-indicator--counters" aria-label="progress">
   <ol class="usa-step-indicator__segments">
     <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
@@ -16,6 +17,6 @@
 
   <div class="margin-top-4 usa-prose">
     <p class="desktop:display-none text-bold">Pending</p>
-    <p>This standard will be pending for one year. Agencies will be required to comply with this standard on September 26, 2025.</p>
+    <p>This standard will be pending for one year. Agencies will be required to comply with this standard on {{ date }}.</p>
   </div>
 </div>

--- a/standards/banner.md
+++ b/standards/banner.md
@@ -6,11 +6,13 @@ why: The banner identifies official websites of federal government organizations
 status: Pending
 description: The federal government banner identifies official federal government sites. Learn how to implement the banner on your federal government site.
 date: "2024-09-26"
+comply_by_date: "September 26th, 2025"
 ---
 
 ## Status
 
-{% include "_includes/status/pending.html" %}
+{% include "_includes/status/pending.html" comply_by_date: comply_by_date %}
+
 
 ## Standard
 

--- a/standards/html-page-title.md
+++ b/standards/html-page-title.md
@@ -6,11 +6,12 @@ why: A descriptive page title is important for accessibility and discoverability
 status: Pending
 description: A descriptive and unique page title is important for accessibility and discoverability. Learn how to create quality HTML page titles for your federal government site.
 date: "2024-09-26"
+comply_by_date: "September 26th, 2025"
 ---
 
 ## Status
 
-{% include "_includes/status/pending.html" %}
+{% include "_includes/status/pending.html" comply_by_date: comply_by_date %}
 
 ## Standard
 

--- a/standards/meta-page-description.md
+++ b/standards/meta-page-description.md
@@ -6,11 +6,12 @@ why: The meta description supports accessibility and discoverability.
 status: Pending
 description: A descriptive and unique meta page description is important for accessibility and discoverability. Learn how to create quality meta page descriptions for your site.
 date: "2024-09-26"
+comply_by_date: "September 26th, 2025"
 ---
 
 ## Status
 
-{% include "_includes/status/pending.html" %}
+{% include "_includes/status/pending.html" comply_by_date: comply_by_date %}
 
 ## Standard
 


### PR DESCRIPTION
## Context
The three current pending standards all have a "required" or "comply by" date of September 26th, 2025 since they were launched at the end of September 2024. As new standards move to "pending", that date will need to be dynamic.

## Description
`_includes/status/pending.html` now accepts a `comply_by_date` from front matter when it's included within one of the standards markdown file. If this value is missing it currently defaults to "September 26th, 2025". The front matter variable is expected to be in the format that you would like the date to appear, no extra formatting is performed.

## How to verify this change
Visit a pending standard page and verify that the text under the "Status" heading and step indicator reads "This standard will be pending for one year. Agencies will be required to comply with this standard on September 26th, 2025.". This is the same thing it says on the live site currently but the date listed is no longer hardcoded in `_includes/status/pending.html`.

[Banner](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/comply-by-date/standards/banner/)
[HTML page title](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/comply-by-date/standards/html-page-title/)
[Meta page description](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/comply-by-date/standards/meta-page-description/)
