### PR TITLE
Change name to the singular to be consistent

### DIFF
--- a/standards/external-link.md
+++ b/standards/external-link.md
@@ -1,13 +1,13 @@
 ---
 layout: layouts/page-single
 tags: standards
-title: External links
+title: External link
 why: Informing users when a link will take them to a different site helps them decide whether or not to click that link. 
 status: Research
 description: We're researching the value of indicating links to external sites clearly and consistently.
 date: "2024-10-11"
 github_discussion_number: 271
-join_the_conversation_name: external links
+join_the_conversation_name: external link
 ---
 
 ## Status


### PR DESCRIPTION
Use "external link" as the standard title instead of "external links" to be consistent with other titles of standards.

[Preview URL](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/singular-title/standards/)
