### PR TITLE
Standards filtering

### DIFF
--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -15,8 +15,6 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   <p>Federal website standards will help agencies provide high-quality, consistent digital experiences for everyone. The standards cover common visual and technical elements and reflect user experience best practices.</p>
   <p>We’ll post information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
 
-  {% include "_includes/step-indicator.html" %}
-
   <div id="status-selectors">
     <ul class="usa-button-group">
       <li class="usa-button-group__item tablet:margin-right-2">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -15,7 +15,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   <p>Federal website standards will help agencies provide high-quality, consistent digital experiences for everyone. The standards cover common visual and technical elements and reflect user experience best practices.</p>
   <p>We’ll post information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
 
-  <div id="status-selectors">
+  <div class="margin-top-5" id="status-selectors">
     <ul class="usa-button-group">
       <li class="usa-button-group__item tablet:margin-right-2">
         <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
@@ -32,7 +32,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
     </ul>
   </div>
 
-  <div class="usa-checkbox">
+  <div class="usa-checkbox margin-bottom-5">
     <input
       class="usa-checkbox__input"
       id="select-all-standards"
@@ -48,12 +48,12 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
     <h2 class="font-heading-xl padding-top-1">There are no statuses selected.</h2>
   </div>
 
-  <div class="transition-display-none" id="required-standards">
+  <div id="required-standards">
     <h2 class="font-heading-xl padding-top-1">Required</h2>
     <p>There are no required standards at this time.</p>
   </div>
 
-  <div class="transition-display-none" id="pending-standards">
+  <div id="pending-standards">
     <h2 class="font-heading-xl padding-top-1">Pending</h2>
     <p>Pending standards are finalized. They will be required after a specified time period following their publication to the pending status. Federal agencies can begin working to comply with pending standards.</p>
     <ul class="usa-card-group padding-top-2" id="pending-ul">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -15,9 +15,8 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   <p>Federal website standards will help agencies provide high-quality, consistent digital experiences for everyone. The standards cover common visual and technical elements and reflect user experience best practices.</p>
   <p>We’ll post information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
 
-  <p>View standards at specific stages</p>
-
-  <div class="margin-top-5" id="status-selectors">
+  <p class="margin-top-5">Select to view standards at specific stages.</p>
+  <div id="status-selectors">
     <ul class="usa-button-group">
       <li class="usa-button-group__item tablet:margin-right-2">
         <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
@@ -47,7 +46,7 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   </div>
 
   <div class="display-none" id="no-statuses-selected">
-    <h2 class="font-heading-xl padding-top-1">There are no statuses selected.</h2>
+    <p class="usa-prose padding-top-1">There are no statuses selected. Please select a status to view a standard.</p>
   </div>
 
   <div id="required-standards">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -19,13 +19,13 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
 
   <div id="status-selectors">
     <ul class="usa-button-group">
-      <li class="usa-button-group__item margin-right-2">
+      <li class="usa-button-group__item tablet:margin-right-2">
         <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
       </li>
-      <li class="usa-button-group__item margin-right-2">
+      <li class="usa-button-group__item tablet:margin-right-2">
         <button type="button" class="usa-button" id="draft-button" data-status="draft" data-selected="true">Draft</button>
       </li>
-      <li class="usa-button-group__item margin-right-2">
+      <li class="usa-button-group__item tablet:margin-right-2">
         <button type="button" class="usa-button" id="pending-button" data-status="pending" data-selected="true">Pending</button>
       </li>
       <li class="usa-button-group__item">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -16,22 +16,52 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   <p>We’ll post information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
 
   <p class="margin-top-5">Select to view standards at specific stages.</p>
+  
   <div id="status-selectors">
-    <ul class="usa-button-group">
-      <li class="usa-button-group__item tablet:margin-right-2">
-        <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
-      </li>
-      <li class="usa-button-group__item tablet:margin-right-2">
-        <button type="button" class="usa-button" id="draft-button" data-status="draft" data-selected="true">Draft</button>
-      </li>
-      <li class="usa-button-group__item tablet:margin-right-2">
-        <button type="button" class="usa-button" id="pending-button" data-status="pending" data-selected="true">Pending</button>
-      </li>
-      <li class="usa-button-group__item">
-        <button type="button" class="usa-button" id="required-button" data-status="required" data-selected="true">Required</button>
-      </li>
-    </ul>
+    <div class="display-none tablet:display-block">
+      <ul class="usa-button-group">
+        <li class="usa-button-group__item grid-col-6 tablet:grid-col-auto">
+          <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
+        </li>
+        <li class="usa-button-group__item grid-col-6 tablet:grid-col-auto">
+          <button type="button" class="usa-button" id="draft-button" data-status="draft" data-selected="true">Draft</button>
+        </li>
+        <li class="usa-button-group__item grid-col-6 tablet:grid-col-auto">
+          <button type="button" class="usa-button" id="pending-button" data-status="pending" data-selected="true">Pending</button>
+        </li>
+        <li class="usa-button-group__item grid-col-6 tablet:grid-col-auto">
+          <button type="button" class="usa-button" id="required-button" data-status="required" data-selected="true">Required</button>
+        </li>
+      </ul>
+    </div>
+
+    {% comment %}
+    These are the status selectors for mobile, it's a different div because we wanted to split the buttons up into
+    two columns on mobile without affecting the desktop look
+    {% endcomment %}
+    <div class="tablet:display-none">
+      <ul class="usa-button-group">
+        <div class="grid-row">
+        <li class="usa-button-group__item grid-col-auto">
+          <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
+        </li>
+        <li class="usa-button-group__item grid-col-auto">
+          <button type="button" class="usa-button" id="draft-button" data-status="draft" data-selected="true">Draft</button>
+        </li>
+        </div>
+        <div class="grid-row">
+        <li class="usa-button-group__item grid-col-auto">
+          <button type="button" class="usa-button" id="pending-button" data-status="pending" data-selected="true">Pending</button>
+        </li>
+        <li class="usa-button-group__item grid-col-auto">
+          <button type="button" class="usa-button" id="required-button" data-status="required" data-selected="true">Required</button>
+        </li>
+        </div>
+      </ul>
+    </div>
   </div>
+
+ 
 
   <div class="usa-checkbox margin-bottom-5">
     <input

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -15,6 +15,8 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
   <p>Federal website standards will help agencies provide high-quality, consistent digital experiences for everyone. The standards cover common visual and technical elements and reflect user experience best practices.</p>
   <p>We’ll post information about standards as they're being developed. Each standard will have a status to indicate where it is in the process: research, draft, pending, or required. </p>
 
+  <p>View standards at specific stages</p>
+
   <div class="margin-top-5" id="status-selectors">
     <ul class="usa-button-group">
       <li class="usa-button-group__item tablet:margin-right-2">

--- a/_includes/layouts/collection.html
+++ b/_includes/layouts/collection.html
@@ -1,5 +1,6 @@
 ---
 layout: layouts/page-columns
+script: standards.js
 ---
 {% comment %}
 This template uses the USWDS card component.
@@ -16,102 +17,144 @@ See https://designsystem.digital.gov/components/card/#when-to-use-the-card-compo
 
   {% include "_includes/step-indicator.html" %}
 
-<h2 class="font-heading-xl padding-top-1">Required</h2>
-<p>There are no required standards at this time.</p>
+  <div id="status-selectors">
+    <ul class="usa-button-group">
+      <li class="usa-button-group__item margin-right-2">
+        <button type="button" class="usa-button" id="research-button" data-status="research" data-selected="true">Research</button>
+      </li>
+      <li class="usa-button-group__item margin-right-2">
+        <button type="button" class="usa-button" id="draft-button" data-status="draft" data-selected="true">Draft</button>
+      </li>
+      <li class="usa-button-group__item margin-right-2">
+        <button type="button" class="usa-button" id="pending-button" data-status="pending" data-selected="true">Pending</button>
+      </li>
+      <li class="usa-button-group__item">
+        <button type="button" class="usa-button" id="required-button" data-status="required" data-selected="true">Required</button>
+      </li>
+    </ul>
+  </div>
 
-<h2 class="font-heading-xl padding-top-1">Pending</h2>
-<p>Pending standards are finalized. They will be required after a specified time period following their publication to the pending status. Federal agencies can begin working to comply with pending standards.</p>
+  <div class="usa-checkbox">
+    <input
+      class="usa-checkbox__input"
+      id="select-all-standards"
+      type="checkbox"
+      name="select-all"
+      value="yes"
+      checked="checked"
+    />
+    <label class="usa-checkbox__label" for="select-all-standards">Select all</label>
+  </div>
 
-<ul class="usa-card-group padding-top-2">
-{%- for standard in collections.standards -%}
-  {% if standard.data.status == "Pending" %}
-  <li class="usa-card mobile:grid-col desktop:grid-col-4">
-    <div class="usa-card__container">
-      <div class="usa-card__header">
-        <h4 class="usa-card__heading">
-          <a
-            class="usa-link font-heading-xl"
-            href="{{ standard.url | url }}"
-            >{{ standard.data.title }}</a
-          >
-        </h4>
-      </div>
-      <div class="usa-card__body">
-        <p><strong>Why: </strong>{{ standard.data.why }}</p>
-        <p><strong>Status: </strong>{{ standard.data.status }}</p>
-      </div>
-      <div class="usa-card__footer text-italic">
-        Published: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+  <div class="display-none" id="no-statuses-selected">
+    <h2 class="font-heading-xl padding-top-1">There are no statuses selected.</h2>
+  </div>
+
+  <div class="transition-display-none" id="required-standards">
+    <h2 class="font-heading-xl padding-top-1">Required</h2>
+    <p>There are no required standards at this time.</p>
+  </div>
+
+  <div class="transition-display-none" id="pending-standards">
+    <h2 class="font-heading-xl padding-top-1">Pending</h2>
+    <p>Pending standards are finalized. They will be required after a specified time period following their publication to the pending status. Federal agencies can begin working to comply with pending standards.</p>
+    <ul class="usa-card-group padding-top-2" id="pending-ul">
+      {%- for standard in collections.standards -%}
+      {% if standard.data.status == "Pending" %}
+      <li class="usa-card mobile:grid-col desktop:grid-col-4" data-status="{{ standard.data.status | downcase }}">
+        <div class="usa-card__container">
+          <span class="card-header-pending-color-splash padding-y-1"></span>
+          <div class="usa-card__header">
+            <h4 class="usa-card__heading">
+              <a
+                class="usa-link font-heading-xl"
+                href="{{ standard.url | url }}"
+              >{{ standard.data.title }}</a
+              >
+            </h4>
+          </div>
+          <div class="usa-card__body">
+            <p><strong>Why: </strong>{{ standard.data.why }}</p>
+            <p><strong>Status: </strong>{{ standard.data.status }}</p>
+          </div>
+          <div class="usa-card__footer text-italic">
+            Published: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
-      </div>
-    </div>
-  </li>
-  {% endif %}
-{%- endfor -%}
-</ul>
+          </div>
+        </div>
+      </li>
+      {% endif %}
+      {%- endfor -%}
+    </ul>
+  </div>
 
-<h2 class="font-heading-xl padding-top-1">Draft</h2>
-<p>This standard has been drafted and is being shared with federal agencies and other stakeholders. Agencies can review and provide feedback.</p>
+  <div id="draft-standards">
+    <h2 class="font-heading-xl padding-top-1">Draft</h2>
+    <p>This standard has been drafted and is being shared with federal agencies and other stakeholders. Agencies can review and provide feedback.</p>
 
-<ul class="usa-card-group padding-top-2">
-{%- for standard in collections.standards -%}
-  {% if standard.data.status == "Draft" %}
-  <li class="usa-card mobile:grid-col desktop:grid-col-4">
-    <div class="usa-card__container">
-      <div class="usa-card__header">
-        <h4 class="usa-card__heading">
-          <a
-            class="usa-link font-heading-xl"
-            href="{{ standard.url | url }}"
-            >{{ standard.data.title }}</a
-          >
-        </h4>
-      </div>
-      <div class="usa-card__body">
-        <p><strong>Why: </strong>{{ standard.data.why }}</p>
-        <p><strong>Status: </strong>{{ standard.data.status }}</p>
-      </div>
-      <div class="usa-card__footer text-italic">
-        Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+    <ul class="usa-card-group padding-top-2" id="draft-ul">
+      {%- for standard in collections.standards -%}
+      {% if standard.data.status == "Draft" %}
+      <li class="usa-card mobile:grid-col desktop:grid-col-4" data-status="{{ standard.data.status | downcase }}">
+        <div class="usa-card__container">
+          <span class="card-header-draft-color-splash padding-y-1"></span>
+          <div class="usa-card__header">
+            <h4 class="usa-card__heading">
+              <a
+                class="usa-link font-heading-xl"
+                href="{{ standard.url | url }}"
+              >{{ standard.data.title }}</a
+              >
+            </h4>
+          </div>
+          <div class="usa-card__body">
+            <p><strong>Why: </strong>{{ standard.data.why }}</p>
+            <p><strong>Status: </strong>{{ standard.data.status }}</p>
+          </div>
+          <div class="usa-card__footer text-italic">
+            Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
-      </div>
-    </div>
-  </li>
-  {% endif %}
-{%- endfor -%}
-</ul>
+          </div>
+        </div>
+      </li>
+      {% endif %}
+      {%- endfor -%}
+    </ul>
+  </div>
 
+  <div id="research-standards">
+    <h2 class="font-heading-xl padding-top-1">Research</h2>
+    <p>These standards are being researched with the public, federal agencies, and other stakeholders. Agencies can contribute research and provide feedback.</p>
 
-<h2 class="font-heading-xl padding-top-1">Research</h2>
-<p>These standards are being researched with the public, federal agencies, and other stakeholders. Agencies can contribute research and provide feedback.</p>
-
-<ul class="usa-card-group padding-top-2">
-{%- for standard in collections.standards -%}
-  {% if standard.data.status == "Research" %}
-  <li class="usa-card mobile:grid-col desktop:grid-col-4">
-    <div class="usa-card__container">
-      <div class="usa-card__header">
-        <h4 class="usa-card__heading">
-          <a
-            class="usa-link font-heading-xl"
-            href="{{ standard.url | url }}"
-            >{{ standard.data.title }}</a
-          >
-        </h4>
-      </div>
-      <div class="usa-card__body">
-        <p><strong>Why: </strong>{{ standard.data.why }}</p>
-        <p><strong>Status: </strong>{{ standard.data.status }}</p>
-      </div>
-      <div class="usa-card__footer text-italic">
-        Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
+    <ul class="usa-card-group padding-top-2" id="research-ul">
+      {%- for standard in collections.standards -%}
+      {% if standard.data.status == "Research" %}
+      <li class="usa-card mobile:grid-col desktop:grid-col-4" data-status="{{ standard.data.status | downcase }}">
+        <div class="usa-card__container">
+          <span class="card-header-research-color-splash padding-y-1"></span>
+          <div class="usa-card__header">
+            <h4 class="usa-card__heading">
+              <a
+                class="usa-link font-heading-xl"
+                href="{{ standard.url | url }}"
+              >{{ standard.data.title }}</a
+              >
+            </h4>
+          </div>
+          <div class="usa-card__body">
+            <p><strong>Why: </strong>{{ standard.data.why }}</p>
+            <p><strong>Status: </strong>{{ standard.data.status }}</p>
+          </div>
+          <div class="usa-card__footer text-italic">
+            Updated: <time datetime="{{ standard.date | toISOString: 'yyyy-MM-dd TTZZ' }}">
               {{ standard.date | toISOString: 'DDD' }}
             </time>
-      </div>
-    </div>
-  </li>
-  {% endif %}
-{%- endfor -%}
-</ul>
+          </div>
+        </div>
+      </li>
+      {% endif %}
+      {%- endfor -%}
+    </ul>
+  </div>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -49,4 +49,13 @@ to modify some of the meta-data for the site, this is the place to do it.
 
       <!-- favicon -->
     <link rel="icon" href="{{ '/_img/favicon/favicon.ico' | url }}" sizes="any" />
+
+  {% comment %}
+  If you define a script in the front matter of a page or layout it will be included here in the head tag.
+  This is useful for scripts that don't need to run on every page. Make sure the script gets added to the
+  entryPoints array in the buildAssets script so that it's added to the assetPaths file.
+  {% endcomment %}
+  {% if script %}
+    <script src="{{ assetPaths[script] }}" defer></script>
+  {% endif %}
 </head>

--- a/config/buildAssets.js
+++ b/config/buildAssets.js
@@ -64,7 +64,7 @@ async function createAssetPaths() {
 
 esbuild
   .build({
-    entryPoints: ["styles/styles.scss", "js/app.js", 'js/uswds-init.js'],
+    entryPoints: ["styles/styles.scss", "js/app.js", 'js/uswds-init.js', 'js/standards.js'],
     entryNames: "[dir]/[name]-[hash]",
     outdir: "_site/assets",
     format: "iife",

--- a/js/standards.js
+++ b/js/standards.js
@@ -1,7 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  // Render all standards based on what's selected
-  // Grab required-standards, pending-standards, draft-standards, research-standards to show/hide
-  // Add click listeners to the four buttons
 
   const statusButtons = document.querySelectorAll('#status-selectors button');
   const requiredDiv = document.getElementById('required-standards');
@@ -11,8 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const selectAllButton = document.getElementById('select-all-standards');
   const noStatusesSelectedDiv = document.getElementById('no-statuses-selected');
 
-  const yaClickedTheButton = (clickEvent) => {
-    console.log('Yep, you clicked. Nice job.');
+  const statusButtonClicked = (clickEvent) => {
     const button = clickEvent.target;
     const status = button.dataset.status;
     let isSelected = (button.dataset.selected === true || button.dataset.selected === 'true');
@@ -115,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   statusButtons.forEach(button => {
-    button.addEventListener('click', yaClickedTheButton);
+    button.addEventListener('click', statusButtonClicked);
   });
 
   selectAllButton.addEventListener('click', selectAll);

--- a/js/standards.js
+++ b/js/standards.js
@@ -1,0 +1,103 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Render all standards based on what's selected
+  // Grab required-standards, pending-standards, draft-standards, research-standards to show/hide
+  // Add click listeners to the four buttons
+
+  const statusButtons = document.querySelectorAll('#status-selectors button');
+  const requiredDiv = document.getElementById('required-standards');
+  const pendingDiv = document.getElementById('pending-standards');
+  const draftDiv = document.getElementById('draft-standards');
+  const researchDiv = document.getElementById('research-standards');
+  const selectAllButton = document.getElementById('select-all-standards');
+  const noStatusesSelectedDiv = document.getElementById('no-statuses-selected');
+
+  const yaClickedTheButton = (clickEvent) => {
+    console.log('Yep, you clicked. Nice job.');
+    const button = clickEvent.target;
+    const status = button.dataset.status;
+    let isSelected = (button.dataset.selected === true || button.dataset.selected === 'true');
+
+    if (isSelected) {
+      button.dataset.selected = false;
+      isSelected = false;
+    } else {
+      button.dataset.selected = true;
+      isSelected = true;
+    }
+
+    switch(status) {
+      case 'required':
+        button.classList.toggle('required-outline');
+        if (isSelected) {
+          requiredDiv.classList.remove('display-none');
+        } else {
+          requiredDiv.classList.add('display-none');
+        }
+        break;
+      case 'pending':
+        button.classList.toggle('pending-outline');
+        if (isSelected) {
+          pendingDiv.classList.remove('display-none');
+        } else {
+          pendingDiv.classList.add('display-none');
+        }
+        break;
+      case 'draft':
+        button.classList.toggle('draft-outline');
+        if (isSelected) {
+          draftDiv.classList.remove('display-none');
+        } else {
+          draftDiv.classList.add('display-none');
+        }
+        break;
+      case 'research':
+        button.classList.toggle('research-outline');
+        if (isSelected) {
+          researchDiv.classList.remove('display-none');
+        } else {
+          researchDiv.classList.add('display-none');
+        }
+        break;
+    }
+
+    const statuses = Array.from(statusButtons);
+    // Should "Select All" be checked?
+    const allStatusesSelected = !statuses.some(areUnselected);
+
+    selectAllButton.checked = allStatusesSelected;
+
+    // At least one status was unselected, check to see if they're all unselected
+    if (!allStatusesSelected) {
+      const everyStatusIsUnselected = statuses.every(areUnselected);
+
+      if (everyStatusIsUnselected) {
+        noStatusesSelectedDiv.classList.remove('display-none');
+      } else {
+        noStatusesSelectedDiv.classList.add('display-none');
+      }
+    }
+  };
+
+  const areUnselected = (button) => {
+    return !(button.dataset.selected === true || button.dataset.selected === 'true');
+  };
+
+  const selectAll = (clickEvent) => {
+    statusButtons.forEach(button => {
+      const status = button.dataset.status;
+      button.dataset.selected = true;
+      button.classList.remove(`${status}-outline`);
+    });
+
+    requiredDiv.classList.remove('display-none');
+    pendingDiv.classList.remove('display-none');
+    draftDiv.classList.remove('display-none');
+    researchDiv.classList.remove('display-none');
+  };
+
+  statusButtons.forEach(button => {
+    button.addEventListener('click', yaClickedTheButton);
+  });
+
+  selectAllButton.addEventListener('click', selectAll);
+});

--- a/js/standards.js
+++ b/js/standards.js
@@ -83,16 +83,35 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const selectAll = (clickEvent) => {
-    statusButtons.forEach(button => {
-      const status = button.dataset.status;
-      button.dataset.selected = true;
-      button.classList.remove(`${status}-outline`);
-    });
+    const clickedOn = clickEvent.target.checked;
 
-    requiredDiv.classList.remove('display-none');
-    pendingDiv.classList.remove('display-none');
-    draftDiv.classList.remove('display-none');
-    researchDiv.classList.remove('display-none');
+    if (clickedOn) {
+      statusButtons.forEach(button => {
+        const status = button.dataset.status;
+        button.dataset.selected = true;
+        button.classList.remove(`${status}-outline`);
+      });
+
+      requiredDiv.classList.remove('display-none');
+      pendingDiv.classList.remove('display-none');
+      draftDiv.classList.remove('display-none');
+      researchDiv.classList.remove('display-none');
+
+      noStatusesSelectedDiv.classList.add('display-none');
+    } else {
+      statusButtons.forEach(button => {
+        const status = button.dataset.status;
+        button.dataset.selected = false;
+        button.classList.add(`${status}-outline`);
+      });
+
+      requiredDiv.classList.add('display-none');
+      pendingDiv.classList.add('display-none');
+      draftDiv.classList.add('display-none');
+      researchDiv.classList.add('display-none');
+
+      noStatusesSelectedDiv.classList.remove('display-none');
+    }
   };
 
   statusButtons.forEach(button => {

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -2,3 +2,9 @@ $hero-blue: #4F97D1;
 $hero-button-active: #1B1B1B;
 $hero-button-default: #1A4480;
 $hero-button-hover: #162E51;
+
+// Standards page status buttons and card tops
+$research: #0C78CF;
+$draft: #1865A3;
+$pending: #244C6C;
+$required: #1F303E;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -22,6 +22,8 @@ Custom styling
 @forward "overrides/_global.scss";
 @forward "overrides/_usa-section.scss";
 
+@use './colors' as *;
+
 /*---------------------------------------------------------
 CHECKLIST 
 ----------------------------------------------------------*/
@@ -39,4 +41,84 @@ CHECKLIST
     content: "\200B"; // Marker is white space but still reads as list item
     padding-left: units(3);
   }
+}
+
+/*---------------------------------------------------------
+Standars index page status button colors and card toppers
+
+:not() is used because when the buttons are deselected,
+usa-button--outline class is added and we don't want to
+override the transparent background-color that comes with
+that class
+----------------------------------------------------------*/
+#status-selectors {
+  #research-button:not(.research-outline) {
+    background-color: $research;
+
+    &:hover {
+      background-color: darken($research, 10%);
+    }
+  }
+
+  .research-outline {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 2px $research;
+    color: #1b1b1b;
+  }
+
+  #draft-button:not(.draft-outline) {
+    background-color: $draft;
+
+    &:hover {
+      background-color: darken($draft, 10%);
+    }
+
+  }
+
+  .draft-outline {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 2px $draft;
+    color: #1b1b1b;
+  }
+
+  #pending-button:not(.pending-outline) {
+    background-color: $pending;
+
+    &:hover {
+      background-color: darken($pending, 10%);
+    }
+
+  }
+
+  .pending-outline {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 2px $pending;
+    color: #1b1b1b;
+  }
+
+  #required-button:not(.required-outline) {
+    background-color: $required;
+
+    &:hover {
+      background-color: darken($required, 10%);
+    }
+  }
+
+  .required-outline {
+    background-color: transparent;
+    box-shadow: inset 0 0 0 2px $required;
+    color: #1b1b1b;
+  }
+}
+
+.card-header-research-color-splash {
+  background-color: $research;
+}
+
+.card-header-draft-color-splash {
+  background-color: $draft;
+}
+
+.card-header-pending-color-splash {
+  background-color: $pending;
 }

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -112,13 +112,31 @@ that class
 }
 
 .card-header-research-color-splash {
+  border: 2px solid $research;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
   background-color: $research;
+  margin-top: -2px;
+  margin-left: -2px;
+  margin-right: -2px;
 }
 
 .card-header-draft-color-splash {
+  border: 2px solid $draft;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
   background-color: $draft;
+  margin-top: -2px;
+  margin-left: -2px;
+  margin-right: -2px;
 }
 
 .card-header-pending-color-splash {
+  border: 2px solid $pending;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
   background-color: $pending;
+  margin-top: -2px;
+  margin-left: -2px;
+  margin-right: -2px;
 }


### PR DESCRIPTION
## Context
We would like to be able to filter the list of standards by their status.

## Description
This fixes #177. I think there may be discussion needed before this lands.

## How to verify this change
1. Visit [the Standards page](https://federalist-142078a8-f654-4daa-8f73-db9770b3ec7a.sites.pages.cloud.gov/preview/gsa-tts/federal-website-standards/caley/standards-filtering/standards/)
2. Interact with the status buttons, they should show/hide as expected
3. Click "Select all", it should select all or deselect all
4. Check the mobile version, it's styled a little differently than the desktop look
